### PR TITLE
Support automatically merging PRs that don't affect target clusters

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -118,7 +118,7 @@ Configuration keys:
 |`autoApprovePromotionPrs`| if true the bot will auto-approve all promotion PRs, with the assumption the original PR was peer reviewed and is promoted verbatim. Required additional GH token via APPROVER_GITHUB_OAUTH_TOKEN env variable|
 |`toggleCommitStatus`| Map of strings, allow (non-repo-admin) users to change the [Github commit status](https://docs.github.com/en/rest/commits/statuses) state(from failure to success and back). This can be used to continue promotion of a change that doesn't pass repo checks. the keys are strings commented in the PRs, values are [Github commit status context](https://docs.github.com/en/rest/commits/statuses?apiVersion=2022-11-28#create-a-commit-status) to be overridden|
 |`commentArgocdDiffonPR`| Uses ArgoCD API to calculate expected changes to k8s state and comment the resulting "diff" as comment in the PR. Requires ARGOCD_* environment variables, see below. |
-|`autoMergeNoDiffPRs`| if true the Telefonistka will **merge** promotion PRs,that are not expected the change target clusters. Requires `commentArgocdDiffonPR` and possibly `autoApprovePromotionPrs`(depending on repo branch protection rules)|
+|`autoMergeNoDiffPRs`| if true, Telefonistka will **merge** promotion PRs that are not expected to change the target clusters. Requires `commentArgocdDiffonPR` and possibly `autoApprovePromotionPrs`(depending on repo branch protection rules)|
 <!-- markdownlint-enable MD033 -->
 
 Example:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -117,6 +117,8 @@ Configuration keys:
 |`dryRunMode`| if true, the bot will just comment the planned promotion on the merged PR|
 |`autoApprovePromotionPrs`| if true the bot will auto-approve all promotion PRs, with the assumption the original PR was peer reviewed and is promoted verbatim. Required additional GH token via APPROVER_GITHUB_OAUTH_TOKEN env variable|
 |`toggleCommitStatus`| Map of strings, allow (non-repo-admin) users to change the [Github commit status](https://docs.github.com/en/rest/commits/statuses) state(from failure to success and back). This can be used to continue promotion of a change that doesn't pass repo checks. the keys are strings commented in the PRs, values are [Github commit status context](https://docs.github.com/en/rest/commits/statuses?apiVersion=2022-11-28#create-a-commit-status) to be overridden|
+|`commentArgocdDiffonPR`| Uses ArgoCD API to calculate expected changes to k8s state and comment the resulting "diff" as comment in the PR. Requires ARGOCD_* environment variables, see below. |
+|`autoMergeNoDiffPRs`| if true the Telefonistka will **merge** promotion PRs,that are not expected the change target clusters. Requires `commentArgocdDiffonPR` and possibly `autoApprovePromotionPrs`(depending on repo branch protection rules)|
 <!-- markdownlint-enable MD033 -->
 
 Example:
@@ -159,6 +161,8 @@ promotionPaths:
         - "clusters/prod/us-east4/c2"
 dryRunMode: true
 autoApprovePromotionPrs: true
+commentArgocdDiffonPR: true
+autoMergeNoDiffPRs: true
 toggleCommitStatus:
   override-terrafrom-pipeline: "github-action-terraform"
 ```

--- a/internal/pkg/configuration/config.go
+++ b/internal/pkg/configuration/config.go
@@ -41,6 +41,7 @@ type Config struct {
 	ToggleCommitStatus      map[string]string      `yaml:"toggleCommitStatus"`
 	WebhookEndpointRegexs   []WebhookEndpointRegex `yaml:"webhookEndpointRegexs"`
 	CommentArgocdDiffonPR   bool                   `yaml:"commentArgocdDiffonPR"`
+	AutoMergeNoDiffPRs      bool                   `yaml:"autoMergeNoDiffPRs"`
 }
 
 func ParseConfigFromYaml(y string) (*Config, error) {

--- a/internal/pkg/githubapi/github.go
+++ b/internal/pkg/githubapi/github.go
@@ -125,7 +125,7 @@ func HandlePREvent(eventPayload *github.PullRequestEvent, ghPrClientDetails GhPr
 						ghPrClientDetails.PrLogger.Debugf("PR %v labeled\n%+v", *eventPayload.PullRequest.Number, prLables)
 					}
 					if DoesPrHasLabel(*eventPayload, "promotion") && config.AutoMergeNoDiffPRs {
-						ghPrClientDetails.PrLogger.Infof("Auto-merging (no diff)PR %d", *eventPayload.PullRequest.Number)
+						ghPrClientDetails.PrLogger.Infof("Auto-merging (no diff) PR %d", *eventPayload.PullRequest.Number)
 						err := MergePr(ghPrClientDetails, eventPayload.PullRequest.Number)
 						if err != nil {
 							prHandleError = err

--- a/internal/pkg/githubapi/github.go
+++ b/internal/pkg/githubapi/github.go
@@ -124,7 +124,14 @@ func HandlePREvent(eventPayload *github.PullRequestEvent, ghPrClientDetails GhPr
 					} else {
 						ghPrClientDetails.PrLogger.Debugf("PR %v labeled\n%+v", *eventPayload.PullRequest.Number, prLables)
 					}
-					// TODO Auto-merge PRs with no changes(optional)
+					if DoesPrHasLabel(*eventPayload, "promotion") && config.AutoMergeNoDiffPRs {
+						ghPrClientDetails.PrLogger.Infof("Auto-merging (no diff)PR %d", *eventPayload.PullRequest.Number)
+						err := MergePr(ghPrClientDetails, eventPayload.PullRequest.Number)
+						if err != nil {
+							prHandleError = err
+							ghPrClientDetails.PrLogger.Errorf("PR auto merge failed: err=%v", err)
+						}
+					}
 				}
 			}
 


### PR DESCRIPTION
## Description

Support automaticallyh merging PRs that don't affect target clusters - those usually happen when you change some component configuration that affect only some of the environments.
We still want to merge these to avoid environment drift.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](https://github.com/wayfair-incubator/telefonistka/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
