### PR TITLE
fix Telefonistka "hungs" on diff when ArgoCD application-controller is down issue

### DIFF
--- a/internal/pkg/argocd/argocd.go
+++ b/internal/pkg/argocd/argocd.go
@@ -192,6 +192,7 @@ func generateDiffOfAComponent(ctx context.Context, componentPath string, prBranc
 		log.Errorf("Error getting app %s: %v", foundApps.Items[0].Name, err)
 		return componentDiffResult
 	}
+	log.Debugf("Got ArgoCD app %s", app.Name)
 	componentDiffResult.ArgoCdAppName = app.Name
 	componentDiffResult.ArgoCdAppURL = fmt.Sprintf("%s/applications/%s", argoSettings.URL, app.Name)
 	resources, err := appIf.ManagedResources(ctx, &application.ResourcesQuery{ApplicationName: &app.Name, AppNamespace: &app.Namespace})
@@ -200,6 +201,7 @@ func generateDiffOfAComponent(ctx context.Context, componentPath string, prBranc
 		log.Errorf("Error getting (live)resources for app %s: %v", app.Name, err)
 		return componentDiffResult
 	}
+	log.Debugf("Got (live)resources for app %s", app.Name)
 
 	// Get the application manifests, these are the target state of the application objects, taken from the git repo, specificly from the PR branch.
 	diffOption := &DifferenceOption{}
@@ -215,6 +217,7 @@ func generateDiffOfAComponent(ctx context.Context, componentPath string, prBranc
 		log.Errorf("Error getting manifests for app %s, revision %s: %v", app.Name, prBranch, err)
 		return componentDiffResult
 	}
+	log.Debugf("Got manifests for app %s, revision %s", app.Name, prBranch)
 	diffOption.res = manifests
 	diffOption.revision = prBranch
 

--- a/internal/pkg/argocd/argocd.go
+++ b/internal/pkg/argocd/argocd.go
@@ -238,34 +238,41 @@ func GenerateDiffOfChangedComponents(ctx context.Context, componentPathList []st
 	// env var should be centralized
 	client, err := createArgoCdClient()
 	if err != nil {
+		log.Errorf("Error creating ArgoCD client: %v", err)
 		return false, true, nil, err
 	}
 
 	conn, appIf, err := client.NewApplicationClient()
 	if err != nil {
+		log.Errorf("Error creating ArgoCD app client: %v", err)
 		return false, true, nil, err
 	}
 	defer argoio.Close(conn)
 
 	conn, projIf, err := client.NewProjectClient()
 	if err != nil {
+		log.Errorf("Error creating ArgoCD project client: %v", err)
 		return false, true, nil, err
 	}
 	defer argoio.Close(conn)
 
 	conn, settingsIf, err := client.NewSettingsClient()
 	if err != nil {
+		log.Errorf("Error creating ArgoCD settings client: %v", err)
 		return false, true, nil, err
 	}
 	defer argoio.Close(conn)
 	argoSettings, err := settingsIf.Get(ctx, &settings.SettingsQuery{})
 	if err != nil {
+		log.Errorf("Error getting ArgoCD settings: %v", err)
 		return false, true, nil, err
 	}
 
+	log.Debugf("Checking diff for components: %v", componentPathList)
 	for _, componentPath := range componentPathList {
 		currentDiffResult := generateDiffOfAComponent(ctx, componentPath, prBranch, repo, appIf, projIf, argoSettings)
 		if currentDiffResult.DiffError != nil {
+			log.Errorf("Error generating diff for component %s: %v", componentPath, currentDiffResult.DiffError)
 			hasComponentDiffErrors = true
 			err = currentDiffResult.DiffError
 		}


### PR DESCRIPTION
## Description
This PR adds move logging of failures in interacting with ArgoCD and make a small change to the context creation to ensure it scoped to webhook event and it has a set timeout.


## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](https://github.com/wayfair-incubator/telefonistka/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
