### PR TITLE
Allow setting argoCD revision to PR git Branch

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -126,6 +126,7 @@ Configuration keys:
 |`commentArgocdDiffonPR`| Uses ArgoCD API to calculate expected changes to k8s state and comment the resulting "diff" as comment in the PR. Requires ARGOCD_* environment variables, see below. |
 |`autoMergeNoDiffPRs`| if true, Telefonistka will **merge** promotion PRs that are not expected to change the target clusters. Requires `commentArgocdDiffonPR` and possibly `autoApprovePromotionPrs`(depending on repo branch protection rules)|
 |`useSHALabelForArgoDicovery`| The default method for discovering relevant ArgoCD applications (for a PR) relies on fetching all applications in the repo and checking the `argocd.argoproj.io/manifest-generate-paths` **annotation**, this might cause a performance issue on a repo with a large number of ArgoCD applications. The alternative is to add SHA1 of the application path as a  **label** and rely on ArgoCD server-side filtering, label name is `telefonistka.io/component-path-sha1`.|
+|`allowSyncArgoCDAppfromBranchPathRegex`| This controls which component(=ArgoCD apps) are allowed to be "applied" from a PR branch, by setting the ArgoCD application `Target Revision` to PR branch.|
 <!-- markdownlint-enable MD033 -->
 
 Example:
@@ -173,6 +174,7 @@ dryRunMode: true
 autoApprovePromotionPrs: true
 commentArgocdDiffonPR: true
 autoMergeNoDiffPRs: true
+allowSyncArgoCDAppfromBranchPathRegex: '^workspace/.*$'
 toggleCommitStatus:
   override-terrafrom-pipeline: "github-action-terraform"
 ```

--- a/internal/pkg/argocd/argocd.go
+++ b/internal/pkg/argocd/argocd.go
@@ -280,6 +280,8 @@ func SetArgoCDAppRevision(ctx context.Context, componentPath string, revision st
 	})
 	if err != nil {
 		return fmt.Errorf("Error setting app %s revision to  %s failed: %v", foundApp.Name, revision, err)
+	} else {
+		log.Infof("ArgoCD App %s revision set to %s", foundApp.Name, revision)
 	}
 
 	return nil

--- a/internal/pkg/argocd/argocd.go
+++ b/internal/pkg/argocd/argocd.go
@@ -160,25 +160,19 @@ func createArgoCdClients() (appClient application.ApplicationServiceClient, proj
 	}
 
 	_, appClient, err = client.NewApplicationClient()
-	// appClntConn, appClient, err := client.NewApplicationClient()
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("Error creating ArgoCD app client: %v", err)
 	}
-	// defer argoio.Close(appClntConn)
 
 	_, projClient, err = client.NewProjectClient()
-	// projClntConn, projClient, err := client.NewProjectClient()
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("Error creating ArgoCD project client: %v", err)
 	}
-	// defer argoio.Close(projClntConn)
 
 	_, settingClient, err = client.NewSettingsClient()
-	// setClntConn, settingClient, err := client.NewSettingsClient()
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("Error creating ArgoCD settings client: %v", err)
 	}
-	// defer argoio.Close(setClntConn)
 	return
 }
 
@@ -264,7 +258,7 @@ func SetArgoCDAppRevision(ctx context.Context, componentPath string, revision st
 		foundApp, err = findArgocdAppByManifestPathAnnotation(ctx, componentPath, repo, appClient)
 	}
 	if err != nil {
-		return fmt.Errorf("Error finding ArgoCD application for component path %s: %v", componentPath, err)
+		return fmt.Errorf("error finding ArgoCD application for component path %s: %w", componentPath, err)
 	}
 	if foundApp.Spec.Source.TargetRevision == revision {
 		log.Infof("App %s already has revision %s", foundApp.Name, revision)
@@ -284,10 +278,9 @@ func SetArgoCDAppRevision(ctx context.Context, componentPath string, revision st
 		return fmt.Errorf("Error marshalling patch object: %v\n%v", err, patchObject)
 	}
 	patch := string(patchJson)
-	// patch := fmt.Sprintf(`{"spec": {"source": {"targetRevision": "%s"}}}`, revision)
 	log.Debugf("Patching app %s/%s with: %s", foundApp.Namespace, foundApp.Name, patch)
 
-	patchType := "merge"
+	const patchType = "merge"
 	patchedApp, err := appClient.Patch(ctx, &application.ApplicationPatchRequest{
 		Name:         &foundApp.Name,
 		AppNamespace: &foundApp.Namespace,
@@ -295,7 +288,7 @@ func SetArgoCDAppRevision(ctx context.Context, componentPath string, revision st
 		Patch:        &patch,
 	})
 	if err != nil {
-		return fmt.Errorf("Error patching app %s revision to  %s failed: %v\n, patch: %v\npatched app: %v\n", foundApp.Name, revision, err, patch, patchedApp)
+		return fmt.Errorf("revision patching failed: %w", err)
 	} else {
 		log.Infof("ArgoCD App %s revision set to %s", foundApp.Name, revision)
 	}

--- a/internal/pkg/argocd/argocd.go
+++ b/internal/pkg/argocd/argocd.go
@@ -284,6 +284,8 @@ func SetArgoCDAppRevision(ctx context.Context, componentPath string, revision st
 	}
 	patch := string(patchJson)
 
+	log.Debugf("Patching app %s/%s with: %s", foundApp.Namespace, foundApp.Name, patch)
+
 	patchType := "merge"
 	_, err = appClient.Patch(ctx, &application.ApplicationPatchRequest{
 		Name:         &foundApp.Name,

--- a/internal/pkg/argocd/argocd.go
+++ b/internal/pkg/argocd/argocd.go
@@ -286,9 +286,10 @@ func SetArgoCDAppRevision(ctx context.Context, componentPath string, revision st
 
 	patchType := "merge"
 	_, err = appClient.Patch(ctx, &application.ApplicationPatchRequest{
-		Name:      &foundApp.Name,
-		PatchType: &patchType,
-		Patch:     &patch,
+		Name:         &foundApp.Name,
+		AppNamespace: &foundApp.Namespace,
+		PatchType:    &patchType,
+		Patch:        &patch,
 	})
 	if err != nil {
 		return fmt.Errorf("Error patching app %s revision to  %s failed: %v\n, patch: %v", foundApp.Name, revision, err, patch)

--- a/internal/pkg/argocd/argocd.go
+++ b/internal/pkg/argocd/argocd.go
@@ -276,7 +276,6 @@ func SetArgoCDAppRevision(ctx context.Context, componentPath string, revision st
 		Spec:         &foundApp.Spec,
 		AppNamespace: &foundApp.Namespace,
 	})
-
 	if err != nil {
 		return fmt.Errorf("Error setting app %s revision to  %s failed: %v", foundApp.Name, revision, err)
 	}

--- a/internal/pkg/argocd/argocd.go
+++ b/internal/pkg/argocd/argocd.go
@@ -23,7 +23,6 @@ import (
 	"github.com/argoproj/gitops-engine/pkg/sync/hook"
 	"github.com/google/go-cmp/cmp"
 	log "github.com/sirupsen/logrus"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -272,30 +271,30 @@ func SetArgoCDAppRevision(ctx context.Context, componentPath string, revision st
 		return nil
 	}
 
-	patchObject := argoappv1.Application{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: foundApp.Namespace,
-		},
-		Spec: argoappv1.ApplicationSpec{
-			Source: &argoappv1.ApplicationSource{
-				TargetRevision: revision,
-			},
-		},
-	}
-	patchJson, err := json.Marshal(patchObject)
-	if err != nil {
-		return fmt.Errorf("Error marshalling patch object: %v\n%v", err, patchObject)
-	}
-	patch := string(patchJson)
-
+	// patchObject := argoappv1.Application{
+	// ObjectMeta: metav1.ObjectMeta{
+	// Namespace: foundApp.Namespace,
+	// },
+	// Spec: argoappv1.ApplicationSpec{
+	// Source: &argoappv1.ApplicationSource{
+	// TargetRevision: revision,
+	// },
+	// },
+	// }
+	// patchJson, err := json.Marshal(patchObject)
+	// if err != nil {
+	// return fmt.Errorf("Error marshalling patch object: %v\n%v", err, patchObject)
+	// }
+	// patch := string(patchJson)
+	patch := fmt.Sprintf(`{"spec": {"source": {"targetRevision": "%s"}}}`, revision)
 	log.Debugf("Patching app %s/%s with: %s", foundApp.Namespace, foundApp.Name, patch)
 
 	patchType := "merge"
 	patchedApp, err := appClient.Patch(ctx, &application.ApplicationPatchRequest{
-		Name:         &foundApp.Name,
-		AppNamespace: &foundApp.Namespace,
-		PatchType:    &patchType,
-		Patch:        &patch,
+		Name: &foundApp.Name,
+		// AppNamespace: &foundApp.Namespace,
+		PatchType: &patchType,
+		Patch:     &patch,
 	})
 	if err != nil {
 		return fmt.Errorf("Error patching app %s revision to  %s failed: %v\n, patch: %v\npatched app: %v\n", foundApp.Name, revision, err, patch, patchedApp)

--- a/internal/pkg/argocd/argocd.go
+++ b/internal/pkg/argocd/argocd.go
@@ -272,16 +272,25 @@ func SetArgoCDAppRevision(ctx context.Context, componentPath string, revision st
 	}
 
 	log.Debugf("=== %v ===", foundApp.Spec.Destination)
-	foundApp.Spec.Source.TargetRevision = revision
 
+	// foundApp.Spec.Source.TargetRevision = revision
 	// _, err = appClient.UpdateSpec(ctx, &application.ApplicationUpdateSpecRequest{
 	// Name:         &foundApp.Name,
 	// Spec:         &foundApp.Spec,
 	// AppNamespace: &foundApp.Namespace,
 	// })
-	_, err = appClient.Update(ctx, &application.ApplicationUpdateRequest{
-		Application: foundApp,
-		Project:     &foundApp.Spec.Project,
+
+	// _, err = appClient.Update(ctx, &application.ApplicationUpdateRequest{
+	// Application: foundApp,
+	// Project:     &foundApp.Spec.Project,
+	// })
+
+	patchType := "merge"
+	patch := fmt.Sprintf(`{"spec": {"source": {"targetRevision": "%s"}}}`, revision)
+	_, err = appClient.Patch(ctx, &application.ApplicationPatchRequest{
+		Name:      &foundApp.Name,
+		PatchType: &patchType,
+		Patch:     &patch,
 	})
 	if err != nil {
 		return fmt.Errorf("Error setting app %s revision to  %s failed: %v", foundApp.Name, revision, err)

--- a/internal/pkg/argocd/argocd.go
+++ b/internal/pkg/argocd/argocd.go
@@ -347,6 +347,7 @@ func generateDiffOfAComponent(ctx context.Context, componentPath string, prBranc
 		return componentDiffResult
 	}
 	log.Debugf("Got (live)resources for app %s", app.Name)
+	log.Debugf("=== resources: %v ===", resources)
 
 	// Get the application manifests, these are the target state of the application objects, taken from the git repo, specificly from the PR branch.
 	diffOption := &DifferenceOption{}
@@ -363,6 +364,7 @@ func generateDiffOfAComponent(ctx context.Context, componentPath string, prBranc
 		return componentDiffResult
 	}
 	log.Debugf("Got manifests for app %s, revision %s", app.Name, prBranch)
+	log.Debugf("=== manifests: %v ===", manifests)
 	diffOption.res = manifests
 	diffOption.revision = prBranch
 

--- a/internal/pkg/argocd/argocd.go
+++ b/internal/pkg/argocd/argocd.go
@@ -271,20 +271,6 @@ func SetArgoCDAppRevision(ctx context.Context, componentPath string, revision st
 		return nil
 	}
 
-	log.Debugf("=== %v ===", foundApp.Spec.Destination)
-
-	// foundApp.Spec.Source.TargetRevision = revision
-	// _, err = appClient.UpdateSpec(ctx, &application.ApplicationUpdateSpecRequest{
-	// Name:         &foundApp.Name,
-	// Spec:         &foundApp.Spec,
-	// AppNamespace: &foundApp.Namespace,
-	// })
-
-	// _, err = appClient.Update(ctx, &application.ApplicationUpdateRequest{
-	// Application: foundApp,
-	// Project:     &foundApp.Spec.Project,
-	// })
-
 	patchType := "merge"
 	patch := fmt.Sprintf(`{"spec": {"source": {"targetRevision": "%s"}}}`, revision)
 	_, err = appClient.Patch(ctx, &application.ApplicationPatchRequest{

--- a/internal/pkg/argocd/argocd.go
+++ b/internal/pkg/argocd/argocd.go
@@ -271,6 +271,7 @@ func SetArgoCDAppRevision(ctx context.Context, componentPath string, revision st
 		return nil
 	}
 
+	log.Debugf("=== %v ===", foundApp.Spec.Destination)
 	foundApp.Spec.Source.TargetRevision = revision
 
 	// _, err = appClient.UpdateSpec(ctx, &application.ApplicationUpdateSpecRequest{

--- a/internal/pkg/argocd/argocd.go
+++ b/internal/pkg/argocd/argocd.go
@@ -273,10 +273,14 @@ func SetArgoCDAppRevision(ctx context.Context, componentPath string, revision st
 
 	foundApp.Spec.Source.TargetRevision = revision
 
-	_, err = appClient.UpdateSpec(ctx, &application.ApplicationUpdateSpecRequest{
-		Name:         &foundApp.Name,
-		Spec:         &foundApp.Spec,
-		AppNamespace: &foundApp.Namespace,
+	// _, err = appClient.UpdateSpec(ctx, &application.ApplicationUpdateSpecRequest{
+	// Name:         &foundApp.Name,
+	// Spec:         &foundApp.Spec,
+	// AppNamespace: &foundApp.Namespace,
+	// })
+	_, err = appClient.Update(ctx, &application.ApplicationUpdateRequest{
+		Application: foundApp,
+		Project:     &foundApp.Spec.Project,
 	})
 	if err != nil {
 		return fmt.Errorf("Error setting app %s revision to  %s failed: %v", foundApp.Name, revision, err)
@@ -284,7 +288,7 @@ func SetArgoCDAppRevision(ctx context.Context, componentPath string, revision st
 		log.Infof("ArgoCD App %s revision set to %s", foundApp.Name, revision)
 	}
 
-	return nil
+	return err
 }
 
 func generateDiffOfAComponent(ctx context.Context, componentPath string, prBranch string, repo string, appClient application.ApplicationServiceClient, projClient projectpkg.ProjectServiceClient, argoSettings *settings.Settings, useSHALabelForArgoDicovery bool) (componentDiffResult DiffResult) {

--- a/internal/pkg/argocd/argocd.go
+++ b/internal/pkg/argocd/argocd.go
@@ -340,6 +340,12 @@ func generateDiffOfAComponent(ctx context.Context, componentPath string, prBranc
 	log.Debugf("Got ArgoCD app %s", app.Name)
 	componentDiffResult.ArgoCdAppName = app.Name
 	componentDiffResult.ArgoCdAppURL = fmt.Sprintf("%s/applications/%s", argoSettings.URL, app.Name)
+
+	if app.Spec.Source.TargetRevision == prBranch {
+		componentDiffResult.DiffError = fmt.Errorf("App %s already has revision %s as Source Target Revision, skipping diff calculation", app.Name, prBranch)
+		return componentDiffResult
+	}
+
 	resources, err := appClient.ManagedResources(ctx, &application.ResourcesQuery{ApplicationName: &app.Name, AppNamespace: &app.Namespace})
 	if err != nil {
 		componentDiffResult.DiffError = err

--- a/internal/pkg/argocd/argocd.go
+++ b/internal/pkg/argocd/argocd.go
@@ -20,7 +20,6 @@ import (
 	argoappv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	argodiff "github.com/argoproj/argo-cd/v2/util/argo/diff"
 	"github.com/argoproj/argo-cd/v2/util/argo/normalizers"
-	argoio "github.com/argoproj/argo-cd/v2/util/io"
 	"github.com/argoproj/gitops-engine/pkg/sync/hook"
 	"github.com/google/go-cmp/cmp"
 	log "github.com/sirupsen/logrus"
@@ -160,23 +159,26 @@ func createArgoCdClients() (appClient application.ApplicationServiceClient, proj
 		return nil, nil, nil, fmt.Errorf("Error creating ArgoCD API client: %v", err)
 	}
 
-	appClntConn, appClient, err := client.NewApplicationClient()
+	_, appClient, err = client.NewApplicationClient()
+	// appClntConn, appClient, err := client.NewApplicationClient()
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("Error creating ArgoCD app client: %v", err)
 	}
-	defer argoio.Close(appClntConn)
+	// defer argoio.Close(appClntConn)
 
-	projClntConn, projClient, err := client.NewProjectClient()
+	_, projClient, err = client.NewProjectClient()
+	// projClntConn, projClient, err := client.NewProjectClient()
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("Error creating ArgoCD project client: %v", err)
 	}
-	defer argoio.Close(projClntConn)
+	// defer argoio.Close(projClntConn)
 
-	setClntConn, settingClient, err := client.NewSettingsClient()
+	_, settingClient, err = client.NewSettingsClient()
+	// setClntConn, settingClient, err := client.NewSettingsClient()
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("Error creating ArgoCD settings client: %v", err)
 	}
-	defer argoio.Close(setClntConn)
+	// defer argoio.Close(setClntConn)
 	return
 }
 

--- a/internal/pkg/configuration/config.go
+++ b/internal/pkg/configuration/config.go
@@ -36,15 +36,16 @@ type Config struct {
 	PromotionPaths []PromotionPath `yaml:"promotionPaths"`
 
 	// Generic configuration
-	PromtionPrLables             []string               `yaml:"promtionPRlables"`
-	DryRunMode                   bool                   `yaml:"dryRunMode"`
-	AutoApprovePromotionPrs      bool                   `yaml:"autoApprovePromotionPrs"`
-	ToggleCommitStatus           map[string]string      `yaml:"toggleCommitStatus"`
-	WebhookEndpointRegexs        []WebhookEndpointRegex `yaml:"webhookEndpointRegexs"`
-	WhProxtSkipTLSVerifyUpstream bool                   `yaml:"whProxtSkipTLSVerifyUpstream"`
-	CommentArgocdDiffonPR        bool                   `yaml:"commentArgocdDiffonPR"`
-	AutoMergeNoDiffPRs           bool                   `yaml:"autoMergeNoDiffPRs"`
-	UseSHALabelForArgoDicovery   bool                   `yaml:"useSHALabelForArgoDicovery"`
+	PromtionPrLables                      []string               `yaml:"promtionPRlables"`
+	DryRunMode                            bool                   `yaml:"dryRunMode"`
+	AutoApprovePromotionPrs               bool                   `yaml:"autoApprovePromotionPrs"`
+	ToggleCommitStatus                    map[string]string      `yaml:"toggleCommitStatus"`
+	WebhookEndpointRegexs                 []WebhookEndpointRegex `yaml:"webhookEndpointRegexs"`
+	WhProxtSkipTLSVerifyUpstream          bool                   `yaml:"whProxtSkipTLSVerifyUpstream"`
+	CommentArgocdDiffonPR                 bool                   `yaml:"commentArgocdDiffonPR"`
+	AutoMergeNoDiffPRs                    bool                   `yaml:"autoMergeNoDiffPRs"`
+	AllowSyncArgoCDAppfromBranchPathRegex string                 `yaml:"allowSyncArgoCDAppfromBranchPathRegex"`
+	UseSHALabelForArgoDicovery            bool                   `yaml:"useSHALabelForArgoDicovery"`
 }
 
 func ParseConfigFromYaml(y string) (*Config, error) {

--- a/internal/pkg/githubapi/github.go
+++ b/internal/pkg/githubapi/github.go
@@ -159,15 +159,15 @@ func HandlePREvent(eventPayload *github.PullRequestEvent, ghPrClientDetails GhPr
 
 			if len(diffOfChangedComponents) > 0 {
 				diffCommentData := struct {
-					diffOfChangedComponents []argocd.DiffResult
-					hasSyncableComponens    bool
+					DiffOfChangedComponents []argocd.DiffResult
+					HasSyncableComponens    bool
 				}{
-					diffOfChangedComponents: diffOfChangedComponents,
+					DiffOfChangedComponents: diffOfChangedComponents,
 				}
 
 				for _, componentPath := range componentPathList {
 					if isSyncFromBranchAllowedForThisPath(config.AllowSyncArgoCDAppfromBranchPathRegex, componentPath) {
-						diffCommentData.hasSyncableComponens = true
+						diffCommentData.HasSyncableComponens = true
 						break
 					}
 				}

--- a/internal/pkg/githubapi/github.go
+++ b/internal/pkg/githubapi/github.go
@@ -126,7 +126,7 @@ func HandlePREvent(eventPayload *github.PullRequestEvent, ghPrClientDetails GhPr
 				prHandleError = err
 				ghPrClientDetails.PrLogger.Errorf("Failed to get ArgoCD diff information: err=%s\n", err)
 			} else {
-				ghPrClientDetails.PrLogger.Debugf("Successfully got ArgoCD diff vs git ref %s", ghPrClientDetails.Ref)
+				ghPrClientDetails.PrLogger.Debugf("Successfully got ArgoCD diff(comparing live objects against objects rendered form git ref %s)", ghPrClientDetails.Ref)
 				if !hasComponentDiffErrors && !hasComponentDiff {
 					ghPrClientDetails.PrLogger.Debugf("ArgoCD diff is empty, this PR will not change cluster state\n")
 					prLables, resp, err := ghPrClientDetails.GhClientPair.v3Client.Issues.AddLabelsToIssue(ghPrClientDetails.Ctx, ghPrClientDetails.Owner, ghPrClientDetails.Repo, *eventPayload.PullRequest.Number, []string{"noop"})

--- a/internal/pkg/githubapi/github.go
+++ b/internal/pkg/githubapi/github.go
@@ -385,6 +385,8 @@ func handleCommentPrEvent(ghPrClientDetails GhPrClientDetails, ce *github.IssueC
 	_, _ = ghPrClientDetails.GetSHA()
 
 	checkboxPattern := `(?m)^\s*-\s*\[(.)\]\s*<!-- telefonistka-argocd-branch-sync -->.*$`
+	ghPrClientDetails.PrLogger.Debugf("=== old body: %s\n", *ce.Changes.Body.From)
+	ghPrClientDetails.PrLogger.Debugf("=== new body: %s\n", *ce.Comment.Body)
 	checkboxWaschecked, checkboxIsChecked := analyzeCommentUpdateCheckBox(*ce.Comment.Body, *ce.Changes.Body.From, checkboxPattern)
 	if !checkboxWaschecked && checkboxIsChecked {
 		ghPrClientDetails.PrLogger.Infof("Sync Checkbox was checked")

--- a/internal/pkg/githubapi/github.go
+++ b/internal/pkg/githubapi/github.go
@@ -322,7 +322,7 @@ func handleEvent(eventPayloadInterface interface{}, mainGhClientCache *lru.Cache
 			"repo":     *eventPayload.Repo.Owner.Login + "/" + *eventPayload.Repo.Name,
 			"prNumber": *eventPayload.Issue.Number,
 		})
-		if *eventPayload.Comment.User.Login != botIdentity {
+		if *eventPayload.Sender.Login != botIdentity {
 			ghPrClientDetails := GhPrClientDetails{
 				Ctx:          ctx,
 				GhClientPair: &mainGithubClientPair,

--- a/internal/pkg/githubapi/github.go
+++ b/internal/pkg/githubapi/github.go
@@ -71,7 +71,6 @@ func (pm prMetadata) serialize() (string, error) {
 }
 
 func (ghPrClientDetails *GhPrClientDetails) getPrMetadata(prBody string) {
-
 	prMetadataRegex := regexp.MustCompile(`<!--\|.*\|(.*)\|-->`)
 	serializedPrMetadata := prMetadataRegex.FindStringSubmatch(prBody)
 	if len(serializedPrMetadata) == 2 {
@@ -83,11 +82,9 @@ func (ghPrClientDetails *GhPrClientDetails) getPrMetadata(prBody string) {
 			}
 		}
 	}
-
 }
 
 func HandlePREvent(eventPayload *github.PullRequestEvent, ghPrClientDetails GhPrClientDetails, mainGithubClientPair GhClientPair, approverGithubClientPair GhClientPair, ctx context.Context) {
-
 	ghPrClientDetails.getPrMetadata(eventPayload.PullRequest.GetBody())
 	// wasCommitStatusSet and the placement of SetCommitStatus in the flow is used to ensure an API call is only made where it needed
 	wasCommitStatusSet := false
@@ -161,7 +158,6 @@ func HandlePREvent(eventPayload *github.PullRequestEvent, ghPrClientDetails GhPr
 			}
 
 			if len(diffOfChangedComponents) > 0 {
-
 				diffCommentData := struct {
 					diffOfChangedComponents []argocd.DiffResult
 					hasSyncableComponens    bool
@@ -414,7 +410,6 @@ func handleCommentPrEvent(ghPrClientDetails GhPrClientDetails, ce *github.IssueC
 						ghPrClientDetails.PrLogger.Errorf("Failed to sync ArgoCD app from branch: err=%s\n", err)
 					}
 				}
-
 			}
 		}
 	}

--- a/internal/pkg/githubapi/github.go
+++ b/internal/pkg/githubapi/github.go
@@ -382,7 +382,7 @@ func handleCommentPrEvent(ghPrClientDetails GhPrClientDetails, ce *github.IssueC
 
 	// This part should only happen on edits of bot comments on open PRs (I'm not testing Issue vs PR as Telefonsitka only creates PRs at this point)
 	if *ce.Action == "edited" && *ce.Comment.User.Login == botIdentity && *ce.Issue.State == "open" {
-		checkboxPattern := `(?m)^\s*-\s*\[(.)\]\s*<!-- telefonistka-argocd-branch-sync -->.*$`
+		const checkboxPattern = `(?m)^\s*-\s*\[(.)\]\s*<!-- telefonistka-argocd-branch-sync -->.*$`
 		checkboxWaschecked, checkboxIsChecked := analyzeCommentUpdateCheckBox(*ce.Comment.Body, *ce.Changes.Body.From, checkboxPattern)
 		if !checkboxWaschecked && checkboxIsChecked {
 			ghPrClientDetails.PrLogger.Infof("Sync Checkbox was checked")

--- a/internal/pkg/githubapi/github.go
+++ b/internal/pkg/githubapi/github.go
@@ -153,8 +153,10 @@ func HandlePREvent(eventPayload *github.PullRequestEvent, ghPrClientDetails GhPr
 				diffCommentData := struct {
 					DiffOfChangedComponents []argocd.DiffResult
 					HasSyncableComponens    bool
+					BranchName              string
 				}{
 					DiffOfChangedComponents: diffOfChangedComponents,
+					BranchName:              ghPrClientDetails.Ref,
 				}
 
 				for _, componentPath := range componentPathList {
@@ -393,7 +395,7 @@ func handleCommentPrEvent(ghPrClientDetails GhPrClientDetails, ce *github.IssueC
 
 				for _, componentPath := range componentPathList {
 					if isSyncFromBranchAllowedForThisPath(config.AllowSyncArgoCDAppfromBranchPathRegex, componentPath) {
-						err := argocd.SetArgoCDAppRevision(ghPrClientDetails.Ctx, componentPath, ghPrClientDetails.PrSHA, ghPrClientDetails.RepoURL, config.UseSHALabelForArgoDicovery)
+						err := argocd.SetArgoCDAppRevision(ghPrClientDetails.Ctx, componentPath, ghPrClientDetails.Ref, ghPrClientDetails.RepoURL, config.UseSHALabelForArgoDicovery)
 						if err != nil {
 							ghPrClientDetails.PrLogger.Errorf("Failed to sync ArgoCD app from branch: err=%s\n", err)
 						}

--- a/internal/pkg/githubapi/github.go
+++ b/internal/pkg/githubapi/github.go
@@ -385,7 +385,7 @@ func handleCommentPrEvent(ghPrClientDetails GhPrClientDetails, ce *github.IssueC
 	_, _ = ghPrClientDetails.GetSHA()
 
 	checkboxPattern := `(?m)^\s*-\s*\[(.)\]\s*<!-- telefonistka-argocd-branch-sync -->.*$`
-	checkboxWaschecked, checkboxIsChecked := analyzeCommentUpdateCheckBox(*ce.Comment.Body, *ce.Issue.Body, checkboxPattern)
+	checkboxWaschecked, checkboxIsChecked := analyzeCommentUpdateCheckBox(*ce.Comment.Body, *ce.Changes.Body.From, checkboxPattern)
 	if !checkboxWaschecked && checkboxIsChecked {
 		ghPrClientDetails.PrLogger.Infof("Sync Checkbox was checked")
 		if config.AllowSyncArgoCDAppfromBranchPathRegex != "" {

--- a/internal/pkg/githubapi/github.go
+++ b/internal/pkg/githubapi/github.go
@@ -126,7 +126,7 @@ func HandlePREvent(eventPayload *github.PullRequestEvent, ghPrClientDetails GhPr
 				prHandleError = err
 				ghPrClientDetails.PrLogger.Errorf("Failed to get ArgoCD diff information: err=%s\n", err)
 			} else {
-				ghPrClientDetails.PrLogger.Debugf("Successfully got ArgoCD diff\n")
+				ghPrClientDetails.PrLogger.Debugf("Successfully got ArgoCD diff vs git ref %s", ghPrClientDetails.Ref)
 				if !hasComponentDiffErrors && !hasComponentDiff {
 					ghPrClientDetails.PrLogger.Debugf("ArgoCD diff is empty, this PR will not change cluster state\n")
 					prLables, resp, err := ghPrClientDetails.GhClientPair.v3Client.Issues.AddLabelsToIssue(ghPrClientDetails.Ctx, ghPrClientDetails.Owner, ghPrClientDetails.Repo, *eventPayload.PullRequest.Number, []string{"noop"})
@@ -302,6 +302,7 @@ func handleEvent(eventPayloadInterface interface{}, mainGhClientCache *lru.Cache
 			PrSHA:        *eventPayload.PullRequest.Head.SHA,
 		}
 
+		log.Debugf("=== Ref is %s\n", ghPrClientDetails.Ref)
 		HandlePREvent(eventPayload, ghPrClientDetails, mainGithubClientPair, approverGithubClientPair, ctx)
 
 	case *github.IssueCommentEvent:

--- a/internal/pkg/githubapi/github_test.go
+++ b/internal/pkg/githubapi/github_test.go
@@ -82,7 +82,7 @@ foobar`
 		t.Error("Expected isCheckedNow to be true")
 	}
 	if wasCheckedBefore {
-		t.Errorf("Expected wasCheckedBeforeto be false, actaully got %t", wasCheckedBefore)
+		t.Errorf("Expected wasCheckedBeforeto be false, got %t", wasCheckedBefore)
 	}
 }
 

--- a/internal/pkg/githubapi/github_test.go
+++ b/internal/pkg/githubapi/github_test.go
@@ -68,7 +68,7 @@ func TestAnalyzeCommentUpdateCheckBox(t *testing.T) {
 	tests := map[string]struct {
 		newBody                  string
 		oldBody                  string
-		checkboxPattern          string
+		checkboxIdentifier       string
 		expectedWasCheckedBefore bool
 		expectedIsCheckedNow     bool
 	}{
@@ -81,7 +81,7 @@ foobar`,
 foobar
 - [x] <!-- check-slug-1 --> Description of checkbox
 foobar`,
-			checkboxPattern:          `(?m)^\s*-\s*\[(.)\]\s*<!-- check-slug-1 -->.*$`,
+			checkboxIdentifier:       "check-slug-1",
 			expectedWasCheckedBefore: false,
 			expectedIsCheckedNow:     true,
 		},
@@ -94,7 +94,7 @@ foobar`,
 foobar
 - [ ] <!-- check-slug-1 --> Description of checkbox
 foobar`,
-			checkboxPattern:          `(?m)^\s*-\s*\[(.)\]\s*<!-- check-slug-1 -->.*$`,
+			checkboxIdentifier:       "check-slug-1",
 			expectedWasCheckedBefore: true,
 			expectedIsCheckedNow:     false,
 		},
@@ -105,7 +105,7 @@ foobar`,
 			newBody: `This is a comment
 foobar
 foobar`,
-			checkboxPattern:          `(?m)^\s*-\s*\[(.)\]\s*<!-- check-slug-1 -->.*$`,
+			checkboxIdentifier:       "check-slug-1",
 			expectedWasCheckedBefore: false,
 			expectedIsCheckedNow:     false,
 		},
@@ -115,7 +115,7 @@ foobar`,
 		name := name
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			wasCheckedBefore, isCheckedNow := analyzeCommentUpdateCheckBox(tc.newBody, tc.oldBody, tc.checkboxPattern)
+			wasCheckedBefore, isCheckedNow := analyzeCommentUpdateCheckBox(tc.newBody, tc.oldBody, tc.checkboxIdentifier)
 			if isCheckedNow != tc.expectedIsCheckedNow {
 				t.Errorf("%s: Expected isCheckedNow to be %v, got %v", name, tc.expectedIsCheckedNow, isCheckedNow)
 			}

--- a/internal/pkg/githubapi/promotion.go
+++ b/internal/pkg/githubapi/promotion.go
@@ -174,15 +174,16 @@ func generateListOfChangedComponentPaths(ghPrClientDetails GhPrClientDetails, co
 	// If the PR has a list of promoted paths in the PR Telefonistika metadata(=is a promotion PR), we use that
 	if len(ghPrClientDetails.PrMetadata.PromotedPaths) > 0 {
 		changedComponentPaths = ghPrClientDetails.PrMetadata.PromotedPaths
-	} else {
-		// If not we will use in-repo config to geenrate it, and turns the map with struct keys into a list of strings
-		relevantComponents, err := generateListOfRelevantComponents(ghPrClientDetails, config)
-		if err != nil {
-			return nil, err
-		}
-		for component := range relevantComponents {
-			changedComponentPaths = append(changedComponentPaths, component.SourcePath+component.ComponentName)
-		}
+		return changedComponentPaths, nil
+	}
+
+	// If not we will use in-repo config to generate it, and turns the map with struct keys into a list of strings
+	relevantComponents, err := generateListOfRelevantComponents(ghPrClientDetails, config)
+	if err != nil {
+		return nil, err
+	}
+	for component := range relevantComponents {
+		changedComponentPaths = append(changedComponentPaths, component.SourcePath+component.ComponentName)
 	}
 	return changedComponentPaths, nil
 }

--- a/internal/pkg/githubapi/promotion.go
+++ b/internal/pkg/githubapi/promotion.go
@@ -170,14 +170,20 @@ type relevantComponent struct {
 	AutoMerge     bool
 }
 
-// This function basically turns the map with struct keys into a list of strings
 func generateListOfChangedComponentPaths(ghPrClientDetails GhPrClientDetails, config *cfg.Config) (changedComponentPaths []string, err error) {
-	relevantComponents, err := generateListOfRelevantComponents(ghPrClientDetails, config)
-	if err != nil {
-		return nil, err
-	}
-	for component := range relevantComponents {
-		changedComponentPaths = append(changedComponentPaths, component.SourcePath+component.ComponentName)
+
+	// If the PR has a list of promoted paths in the PR Telefonistika metadata(=is a promotion PR), we use that
+	if len(ghPrClientDetails.PrMetadata.PromotedPaths) > 0 {
+		changedComponentPaths = ghPrClientDetails.PrMetadata.PromotedPaths
+	} else {
+		// If not we will use in-repo config to geenrate it, and turns the map with struct keys into a list of strings
+		relevantComponents, err := generateListOfRelevantComponents(ghPrClientDetails, config)
+		if err != nil {
+			return nil, err
+		}
+		for component := range relevantComponents {
+			changedComponentPaths = append(changedComponentPaths, component.SourcePath+component.ComponentName)
+		}
 	}
 	return changedComponentPaths, nil
 }

--- a/internal/pkg/githubapi/promotion.go
+++ b/internal/pkg/githubapi/promotion.go
@@ -171,7 +171,6 @@ type relevantComponent struct {
 }
 
 func generateListOfChangedComponentPaths(ghPrClientDetails GhPrClientDetails, config *cfg.Config) (changedComponentPaths []string, err error) {
-
 	// If the PR has a list of promoted paths in the PR Telefonistika metadata(=is a promotion PR), we use that
 	if len(ghPrClientDetails.PrMetadata.PromotedPaths) > 0 {
 		changedComponentPaths = ghPrClientDetails.PrMetadata.PromotedPaths

--- a/templates/argoCD-diff-pr-comment.gotmpl
+++ b/templates/argoCD-diff-pr-comment.gotmpl
@@ -1,6 +1,6 @@
 {{define "argoCdDiff"}}
 Diff of ArgoCD applications:
-{{ range $appDiffResult := . }}
+{{ range $appDiffResult := .diffOfChangedComponents }}
 
 
 {{if $appDiffResult.DiffError }}
@@ -32,4 +32,10 @@ No diff 🤷
 {{- end }}
 
 {{- end }}
+
+{{- if .hasSyncableComponens }}
+- [ ] <!-- telefonistka-argocd-branch-sync --> Set ArgoCD apps to sync to current branch revision  
+{{- end}}
+
+
 {{- end }}

--- a/templates/argoCD-diff-pr-comment.gotmpl
+++ b/templates/argoCD-diff-pr-comment.gotmpl
@@ -35,7 +35,7 @@ No diff 🤷
 
 {{- if .HasSyncableComponens }}
 
-- [ ] <!-- telefonistka-argocd-branch-sync --> Set ArgoCD apps to sync to current branch revision  
+- [ ] <!-- telefonistka-argocd-branch-sync --> Set ArgoCD apps Target Revision to `{{ .BranchName }}`  
 
 {{ end}}
 

--- a/templates/argoCD-diff-pr-comment.gotmpl
+++ b/templates/argoCD-diff-pr-comment.gotmpl
@@ -34,8 +34,10 @@ No diff 🤷
 {{- end }}
 
 {{- if .HasSyncableComponens }}
+
 - [ ] <!-- telefonistka-argocd-branch-sync --> Set ArgoCD apps to sync to current branch revision  
-{{- end}}
+
+{{ end}}
 
 
 {{- end }}

--- a/templates/argoCD-diff-pr-comment.gotmpl
+++ b/templates/argoCD-diff-pr-comment.gotmpl
@@ -1,6 +1,6 @@
 {{define "argoCdDiff"}}
 Diff of ArgoCD applications:
-{{ range $appDiffResult := .diffOfChangedComponents }}
+{{ range $appDiffResult := .DiffOfChangedComponents }}
 
 
 {{if $appDiffResult.DiffError }}
@@ -33,7 +33,7 @@ No diff 🤷
 
 {{- end }}
 
-{{- if .hasSyncableComponens }}
+{{- if .HasSyncableComponens }}
 - [ ] <!-- telefonistka-argocd-branch-sync --> Set ArgoCD apps to sync to current branch revision  
 {{- end}}
 


### PR DESCRIPTION
## Description

- New function `SetArgoCDAppRevision` sets ArgoCD application Target Revsion, note: It doesn't trigger a sync by itself , and it doesn't enable/disable autosync.
- Create a new configuration to control which ArgoCD apps are allowed to sync to non main branch by Telefonistka 
- User triggers  the `SetArgoCDAppRevision` function by checking a checkbox in the ArgoCD diff comment (the comment is displayed only for relevant apps), the will set the app target revision to the PR branch (=next commits in PR will  be synced from this point **and no diff will be displayed** ).
- On PR merge `SetArgoCDAppRevision` is used a gain to revert app to point to `HEAD`
- `generateListOfChangedComponentPaths` function now includes the logic for promotion and "regular" PRs (for DRYness)
- Refactor `createArgoCdClient` to create all needed clients (we need to cache those outside the stack at some point )
- add `analyzeCommentUpdateCheckBox` function to support generic triggering of actions from checkbox



## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](https://github.com/wayfair-incubator/telefonistka/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
