### PR TITLE
Use "concise" diff comment in cases "regular" diff comment is > 65536

### DIFF
--- a/templates/argoCD-diff-pr-comment-concise.gotmpl
+++ b/templates/argoCD-diff-pr-comment-concise.gotmpl
@@ -1,0 +1,47 @@
+{{define "argoCdDiffConcise"}}
+Diff of ArgoCD applications(⚠️ concise view, full diff didn't fit GH comment):
+{{ range $appDiffResult := .DiffOfChangedComponents }}
+
+
+{{if $appDiffResult.DiffError }}
+⚠️ ⚠️ **Error getting diff from ArgoCD** (`{{ $appDiffResult.ComponentPath }}`) ⚠️ ⚠️ 
+``` 
+{{ $appDiffResult.DiffError }}
+
+```
+
+{{- else }}
+<img src="https://argo-cd.readthedocs.io/en/stable/assets/favicon.png" width="20"/> **[{{ $appDiffResult.ArgoCdAppName }}]({{ $appDiffResult.ArgoCdAppURL }})** @ `{{ $appDiffResult.ComponentPath }}`
+{{if $appDiffResult.HasDiff }}
+
+<details><summary>ArgoCD list of changed objects(Click to expand):</summary>
+
+{{ range $objectDiff := $appDiffResult.DiffElements }}
+{{-  if $objectDiff.Diff}}
+`{{ $objectDiff.ObjectNamespace }}/{{ $objectDiff.ObjectKind}}/{{ $objectDiff.ObjectName }}`
+{{- end}}
+{{- end }}
+
+</details>
+{{- else }}
+No diff 🤷
+{{- end}}
+{{if $appDiffResult.AppWasTemporarilyCreated }}
+⚠️ ⚠️ ⚠️
+This PR appears to create this new application, Telefonistka has **temporarly** created an ArgoCD app object for it just to render its manifests.
+It will not be present in ArgoCD UI for more than a few seconds and it can not be synced from the PR branch
+⚠️ ⚠️ ⚠️
+{{- end}}
+
+{{- end }}
+
+{{- end }}
+
+{{- if .HasSyncableComponens }}
+
+- [ ] <!-- telefonistka-argocd-branch-sync --> Set ArgoCD apps Target Revision to `{{ .BranchName }}`  
+
+{{ end}}
+
+
+{{- end }}


### PR DESCRIPTION
## Description
This pull request introduces several improvements to the handling and logging of ArgoCD diff comments, including the addition of a concise template for large comments, and refactoring of error logging. The most important changes include defining a constant for the maximum GitHub comment size, adding logic to handle large diff comments, and creating a concise template for such comments.

### Improvements to handling large diff comments:

* [`internal/pkg/githubapi/github.go`](diffhunk://#diff-7026d4022cf2566206acc90b901d7e6b0dd6969e5ef2f862c963f6552b7becfeR31-R32): Defined a new constant `githubCommentMaxSize` to specify the maximum size of GitHub comments.
* [`internal/pkg/githubapi/github.go`](diffhunk://#diff-7026d4022cf2566206acc90b901d7e6b0dd6969e5ef2f862c963f6552b7becfeL189-R204): Added logic to check the size of the generated diff comment and switch to a concise template if the comment is too large.

### Enhancements to logging:

* [`internal/pkg/githubapi/github.go`](diffhunk://#diff-7026d4022cf2566206acc90b901d7e6b0dd6969e5ef2f862c963f6552b7becfeL189-R204): Refactored error logging to use `ghPrClientDetails.PrLogger` instead of the global `log` object for more consistent and contextual logging.

### New concise template:

* [`templates/argoCD-diff-pr-comment-concise.gotmpl`](diffhunk://#diff-9e640a58c5bd625bb582832d3b5abfeedd9b2b3b824d63098bb625f5bede86e2R1-R47): Created a new concise template for ArgoCD diff comments that are too large to fit within the GitHub comment size limit.
Please provide a meaningful description of what this change will do, or is for. Bonus points for including links to related issues, other PRs, or technical references.

Example of concise image:
![image](https://github.com/user-attachments/assets/c2f84fb0-3581-42ea-979d-d6151f9c672c)



## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](https://github.com/wayfair-incubator/telefonistka/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
