### PR TITLE
Help user to debug the diff error with temporary applications

### DIFF
--- a/internal/pkg/argocd/argocd.go
+++ b/internal/pkg/argocd/argocd.go
@@ -521,7 +521,9 @@ func generateDiffOfAComponent(ctx context.Context, commentDiff bool, componentPa
 	log.Debugf("Generating diff for component %s", componentPath)
 	componentDiffResult.HasDiff, componentDiffResult.DiffElements, componentDiffResult.DiffError = generateArgocdAppDiff(ctx, commentDiff, app, detailedProject.Project, resources, argoSettings, diffOption)
 
-	if componentDiffResult.AppWasTemporarilyCreated {
+	// only delete the temprorary app object if it was created and there was no error on diff
+	// otherwise let's keep it for investigation
+	if componentDiffResult.AppWasTemporarilyCreated && componentDiffResult.DiffError == nil {
 		// Delete the temporary app object
 		_, err = ac.app.Delete(ctx, &application.ApplicationDeleteRequest{Name: &app.Name, AppNamespace: &app.Namespace})
 		if err != nil {

--- a/templates/argoCD-diff-pr-comment.gotmpl
+++ b/templates/argoCD-diff-pr-comment.gotmpl
@@ -4,8 +4,12 @@ Diff of ArgoCD applications:
 
 
 {{if $appDiffResult.DiffError }}
-⚠️ ⚠️ **Error getting diff from ArgoCD** (`{{ $appDiffResult.ComponentPath }}`) ⚠️ ⚠️ 
-``` 
+⚠️ ⚠️ **Error getting diff from ArgoCD** (`{{ $appDiffResult.ComponentPath }}`) ⚠️ ⚠️
+Please check the App Conditions of <img src="https://argo-cd.readthedocs.io/en/stable/assets/favicon.png" width="20"/> **[{{ $appDiffResult.ArgoCdAppName }}]({{ $appDiffResult.ArgoCdAppURL }})** for more details.
+{{- if $appDiffResult.AppWasTemporarilyCreated }}
+⚠️ For investigation we kept the temporary application, please make sure to clean it up later! ⚠️
+{{- end}}
+```
 {{ $appDiffResult.DiffError }}
 
 ```


### PR DESCRIPTION
## Description
In some cases, users cannot get the diff from ArgoCD due to an error on diffing.
This is normally because the `NormalizedLiveState` is empty due to an app condition error.
In this case, we should keep the temporary application for investigation purposes, and let the user know how to debug it.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](https://github.com/wayfair-incubator/telefonistka/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
