### PR TITLE
SD 683 - Custom Commit Status URL

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -91,6 +91,12 @@ Environment variables for the webhook process:
 
 `TEMPLATES_PATH` Telefonistka uses Go templates to format GitHub PR comments, the variable override the default templates path("templates/"), useful for environments where the container workdir is overridden(like GitHub Actions) or when custom templates are desired.
 
+`CUSTOM_COMMIT_STATUS_URL_TEMPLATE_PATH` allows you to set a custom [commit status](https://docs.github.com/en/rest/commits/statuses?apiVersion=2022-11-28#about-commit-statuses) target URL using Go templates. The commit time will be passed as a dynamic parameter to the template. Here is an example:
+```
+https://custom-url.com?time={{.CommitTime}}
+```
+
+
 `ARGOCD_SERVER_ADDR` Hostname and port of the ArgoCD API endpoint, like `argocd-server.argocd.svc.cluster.local:443`, default is `localhost:8080"`
 
 `ARGOCD_TOKEN` ArgoCD authentication token.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -92,10 +92,10 @@ Environment variables for the webhook process:
 `TEMPLATES_PATH` Telefonistka uses Go templates to format GitHub PR comments, the variable override the default templates path("templates/"), useful for environments where the container workdir is overridden(like GitHub Actions) or when custom templates are desired.
 
 `CUSTOM_COMMIT_STATUS_URL_TEMPLATE_PATH` allows you to set a custom [commit status](https://docs.github.com/en/rest/commits/statuses?apiVersion=2022-11-28#about-commit-statuses) target URL using Go templates. The commit time will be passed as a dynamic parameter to the template. Here is an example:
-```
+
+```console
 https://custom-url.com?time={{.CommitTime}}
 ```
-
 
 `ARGOCD_SERVER_ADDR` Hostname and port of the ArgoCD API endpoint, like `argocd-server.argocd.svc.cluster.local:443`, default is `localhost:8080"`
 

--- a/internal/pkg/githubapi/github.go
+++ b/internal/pkg/githubapi/github.go
@@ -1236,8 +1236,7 @@ func commitStatusTargetURL(commitTime time.Time) string {
 	}
 	renderedURL, err := executeTemplate(tmplName, tmplFile, p)
 	if err != nil {
-		// TODO: why we cannot use warnf here?
-		log.Errorf("Failed to render target URL template: %v", err)
+		log.Debugf("Failed to render target URL template: %v", err)
 		return targetURL
 	}
 

--- a/internal/pkg/githubapi/github.go
+++ b/internal/pkg/githubapi/github.go
@@ -1223,7 +1223,7 @@ func GetFileContent(ghPrClientDetails GhPrClientDetails, branch string, filePath
 // it returns a default URL.
 // passed parameter commitTime can be used in the template as .CommitTime
 func commitStatusTargetURL(commitTime time.Time) string {
-	targetURL := "https://github.com/wayfair-incubator/telefonistka"
+	const targetURL string = "https://github.com/wayfair-incubator/telefonistka"
 
 	tmplFile := os.Getenv("CUSTOM_COMMIT_STATUS_URL_TEMPLATE_PATH")
 	tmplName := filepath.Base(tmplFile)

--- a/internal/pkg/githubapi/promotion.go
+++ b/internal/pkg/githubapi/promotion.go
@@ -76,7 +76,7 @@ func DetectDrift(ghPrClientDetails GhPrClientDetails) error {
 		}
 	}
 	if len(diffOutputMap) != 0 {
-		err, templateOutput := executeTemplate("driftMsg", "drift-pr-comment.gotmpl", diffOutputMap)
+		templateOutput, err := executeTemplate("driftMsg", "drift-pr-comment.gotmpl", diffOutputMap)
 		if err != nil {
 			return err
 		}

--- a/internal/pkg/githubapi/promotion.go
+++ b/internal/pkg/githubapi/promotion.go
@@ -76,7 +76,7 @@ func DetectDrift(ghPrClientDetails GhPrClientDetails) error {
 		}
 	}
 	if len(diffOutputMap) != 0 {
-		templateOutput, err := executeTemplate("driftMsg", "drift-pr-comment.gotmpl", diffOutputMap)
+		templateOutput, err := executeTemplate("driftMsg", defaultTemplatesFullPath("drift-pr-comment.gotmpl"), diffOutputMap)
 		if err != nil {
 			return err
 		}

--- a/internal/pkg/githubapi/testdata/custom_commit_status_invalid_template.gotmpl
+++ b/internal/pkg/githubapi/testdata/custom_commit_status_invalid_template.gotmpl
@@ -1,0 +1,1 @@
+https://custom-url.com?time={{.InvalidField}}

--- a/internal/pkg/githubapi/testdata/custom_commit_status_valid_template.gotmpl
+++ b/internal/pkg/githubapi/testdata/custom_commit_status_valid_template.gotmpl
@@ -1,0 +1,1 @@
+{{ $calculated_time := .CommitTime.Add -600000000000 }}https://custom-url.com?time={{.CommitTime.UnixMilli}}&calculated_time={{$calculated_time.UnixMilli}}

--- a/mirrord.json
+++ b/mirrord.json
@@ -10,7 +10,7 @@
     "fs": {
       "mode": "read",
       "read_write": ".+\\.json" ,
-      "read_only": [ "^/etc/telefonistka-gh-app-creds/.*" ]
+      "read_only": [ "^/etc/telefonistka-gh-app-creds/.*",  "^/etc/telefonistka-gh-app-config/.*" ]
     },
     "network": {
       "incoming": "steal",


### PR DESCRIPTION
## Description
Considerations:
1. Passing command flags instead of `CUSTOM_COMMIT_STATUS_URL_TEMPLATE_PATH`: the current implementation is more toward using env variable to flags to keep focus on the implementation of this feature we don't do that
2. Reading env variable in `commitStatusTargetURL` instead of loading it in application startup: the current code doesn't have the flexibility to read the env on start-up and expose as config it to the rest of the application. To change 
that we need to change a couple of functions signature and it goes out of scope for this PR. see [here](https://commercetools.atlassian.net/browse/SD-683?focusedCommentId=836752)

Read this PR commit by commit, to understand the changes:

Feature:
- [Generate target URL with dynamic value (CommitTime)](https://github.com/commercetools/telefonistka/pull/30/commits/4d90984dbe4d67294c0c66286b82a825987b2ce2)
- [Inject /etc/telefonistka-gh-app-config/ for mirrord - will be used for  CUSTOM_COMMIT_STATUS_URL_TEMPLATE_PATH](https://github.com/commercetools/telefonistka/pull/30/commits/333dfdc11023cf85b9318c029bdc137f076baf5b) 
- [Add doc](https://github.com/commercetools/telefonistka/pull/30/commits/3f225ad801d3490bfee9762f0899b7d954e6892d)
- [Add test](https://github.com/commercetools/telefonistka/pull/30/commits/52e02a77afe26c2690a087d0a9f467fbf8f1efb9)


Extra Adjustments:
- [Return err as second value](https://github.com/commercetools/telefonistka/pull/30/commits/1b8c25aac427cd67abee9960d6bdce1ae0ccf09c)
- [Make executeTemplate more general by extracting template path join](https://github.com/commercetools/telefonistka/pull/30/commits/9af06f13cb02a542ffcf656aee3a46d871b3806d)


This will be used for CUSTOM_COMMIT_STATUS_URL_TEMPLATE_PATH
## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](https://github.com/wayfair-incubator/telefonistka/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
