### PR TITLE
Sd 805 improve diff comment

### DIFF
--- a/internal/pkg/githubapi/github.go
+++ b/internal/pkg/githubapi/github.go
@@ -110,9 +110,6 @@ func (ghPrClientDetails *GhPrClientDetails) getBlameURLPrefix() string {
 // - The component is allowed to be synced from a branch(based on Telefonsitka configuration)
 // - The relevant app is not new, temporary app that was created just to generate the diff
 func shouldSyncBranchCheckBoxBeDisplayed(componentPathList []string, allowSyncfromBranchPathRegex string, diffOfChangedComponents []argocd.DiffResult) bool {
-	var displaySyncBranchCheckBox bool
-
-outOfLoop:
 	for _, componentPath := range componentPathList {
 		// First we check if the component is allowed to be synced from a branch
 		if !isSyncFromBranchAllowedForThisPath(allowSyncfromBranchPathRegex, componentPath) {
@@ -122,13 +119,11 @@ outOfLoop:
 		// We don't support syncing new apps from branches
 		for _, diffOfChangedComponent := range diffOfChangedComponents {
 			if diffOfChangedComponent.ComponentPath == componentPath && !diffOfChangedComponent.AppWasTemporarilyCreated {
-				displaySyncBranchCheckBox = true
-				break outOfLoop
+				return true
 			}
 		}
 	}
-
-	return displaySyncBranchCheckBox
+	return false
 }
 
 func HandlePREvent(eventPayload *github.PullRequestEvent, ghPrClientDetails GhPrClientDetails, mainGithubClientPair GhClientPair, approverGithubClientPair GhClientPair, ctx context.Context) {

--- a/internal/pkg/githubapi/github_test.go
+++ b/internal/pkg/githubapi/github_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/wayfair-incubator/telefonistka/internal/pkg/argocd"
 )
 
 func TestGenerateSafePromotionBranchName(t *testing.T) {
@@ -287,5 +288,58 @@ func TestGhPrClientDetailsGetBlameURLPrefix(t *testing.T) {
 		ghPrClientDetails := &GhPrClientDetails{Owner: tc.Owner, Repo: tc.Repo}
 		blameURLPrefix := ghPrClientDetails.getBlameURLPrefix()
 		assert.Equal(t, tc.ExpectURL, blameURLPrefix)
+	}
+}
+
+func TestShouldSyncBranchCheckBoxBeDisplayed(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		componentPathList            []string
+		allowSyncfromBranchPathRegex string
+		diffOfChangedComponents      []argocd.DiffResult
+		expected                     bool
+	}{
+		"New App": {
+			componentPathList:            []string{"workspace/app1"},
+			allowSyncfromBranchPathRegex: `^workspace/.*$`,
+			diffOfChangedComponents: []argocd.DiffResult{
+				{
+					AppWasTemporarilyCreated: true,
+					ComponentPath:            "workspace/app1",
+				},
+			},
+			expected: false,
+		},
+		"Existing App": {
+			componentPathList:            []string{"workspace/app1"},
+			allowSyncfromBranchPathRegex: `^workspace/.*$`,
+			diffOfChangedComponents: []argocd.DiffResult{
+				{
+					AppWasTemporarilyCreated: false,
+					ComponentPath:            "workspace/app1",
+				},
+			},
+			expected: true,
+		},
+		"Mixed New and Existing Apps": {
+			componentPathList:            []string{"workspace/app1", "workspace/app2"},
+			allowSyncfromBranchPathRegex: `^workspace/.*$`,
+			diffOfChangedComponents: []argocd.DiffResult{
+				{
+					AppWasTemporarilyCreated: false,
+					ComponentPath:            "workspace/app1",
+				},
+				{
+					AppWasTemporarilyCreated: true,
+					ComponentPath:            "workspace/app2",
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for i, tc := range tests {
+		result := shouldSyncBranchCheckBoxBeDisplayed(tc.componentPathList, tc.allowSyncfromBranchPathRegex, tc.diffOfChangedComponents)
+		assert.Equal(t, tc.expected, result, i)
 	}
 }

--- a/internal/pkg/githubapi/testdata/diff_comment_data_test.json
+++ b/internal/pkg/githubapi/testdata/diff_comment_data_test.json
@@ -74,7 +74,7 @@
       "AppWasTemporarilyCreated": false
     }
   ],
-  "HasSyncableComponents": false,
+  "DisplaySyncBranchCheckBox": false,
   "BranchName": "promotions/284-simulate-error-5c159151017f",
   "Header": ""
 }

--- a/templates/argoCD-diff-pr-comment-concise.gotmpl
+++ b/templates/argoCD-diff-pr-comment-concise.gotmpl
@@ -37,7 +37,7 @@ It will not be present in ArgoCD UI for more than a few seconds and it can not b
 
 {{- end }}
 
-{{- if .HasSyncableComponents }}
+{{- if .DisplaySyncBranchCheckBox }}
 
 - [ ] <!-- telefonistka-argocd-branch-sync --> Set ArgoCD apps Target Revision to `{{ .BranchName }}`  
 

--- a/templates/argoCD-diff-pr-comment-concise.gotmpl
+++ b/templates/argoCD-diff-pr-comment-concise.gotmpl
@@ -4,7 +4,9 @@ Diff of ArgoCD applications(⚠️ concise view, full diff didn't fit GH comment
 
 
 {{if $appDiffResult.DiffError }}
-⚠️ ⚠️ **Error getting diff from ArgoCD** (`{{ $appDiffResult.ComponentPath }}`) ⚠️ ⚠️ 
+> [!CAUTION]
+> **Error getting diff from ArgoCD** (`{{ $appDiffResult.ComponentPath }}`)
+
 ``` 
 {{ $appDiffResult.DiffError }}
 
@@ -27,10 +29,9 @@ Diff of ArgoCD applications(⚠️ concise view, full diff didn't fit GH comment
 No diff 🤷
 {{- end}}
 {{if $appDiffResult.AppWasTemporarilyCreated }}
-⚠️ ⚠️ ⚠️
-This PR appears to create this new application, Telefonistka has **temporarly** created an ArgoCD app object for it just to render its manifests.
-It will not be present in ArgoCD UI for more than a few seconds and it can not be synced from the PR branch
-⚠️ ⚠️ ⚠️
+> [!NOTE]
+> This PR appears to create this new application, Telefonistka has **temporarly** created an ArgoCD app object for it just to render its manifests.
+> It will not be present in ArgoCD UI for more than a few seconds.
 {{- end}}
 
 {{- end }}

--- a/templates/argoCD-diff-pr-comment.gotmpl
+++ b/templates/argoCD-diff-pr-comment.gotmpl
@@ -47,7 +47,7 @@ It will not be present in ArgoCD UI for more than a few seconds and it can not b
 
 {{- end }}
 
-{{- if .HasSyncableComponents }}
+{{- if .DisplaySyncBranchCheckBox }}
 
 - [ ] <!-- telefonistka-argocd-branch-sync --> Set ArgoCD apps Target Revision to `{{ .BranchName }}`  
 

--- a/templates/argoCD-diff-pr-comment.gotmpl
+++ b/templates/argoCD-diff-pr-comment.gotmpl
@@ -7,10 +7,14 @@ Diff of ArgoCD applications:
 
 
 {{if $appDiffResult.DiffError }}
-⚠️ ⚠️ **Error getting diff from ArgoCD** (`{{ $appDiffResult.ComponentPath }}`) ⚠️ ⚠️
+> [!CAUTION]
+> **Error getting diff from ArgoCD** (`{{ $appDiffResult.ComponentPath }}`)
+
 Please check the App Conditions of <img src="https://argo-cd.readthedocs.io/en/stable/assets/favicon.png" width="20"/> **[{{ $appDiffResult.ArgoCdAppName }}]({{ $appDiffResult.ArgoCdAppURL }})** for more details.
 {{- if $appDiffResult.AppWasTemporarilyCreated }}
-⚠️ For investigation we kept the temporary application, please make sure to clean it up later! ⚠️
+> [!WARNING]
+> For investigation we kept the temporary application, please make sure to clean it up later!
+
 {{- end}}
 ```
 {{ $appDiffResult.DiffError }}
@@ -37,10 +41,9 @@ Please check the App Conditions of <img src="https://argo-cd.readthedocs.io/en/s
 No diff 🤷
 {{- end}}
 {{if $appDiffResult.AppWasTemporarilyCreated }}
-⚠️ ⚠️ ⚠️
-This PR appears to create this new application, Telefonistka has **temporarly** created an ArgoCD app object for it just to render its manifests.
-It will not be present in ArgoCD UI for more than a few seconds and it can not be synced from the PR branch
-⚠️ ⚠️ ⚠️
+> [!NOTE]
+> This PR appears to create this new application, Telefonistka has **temporarly** created an ArgoCD app object for it just to render its manifests.
+> It will not be present in ArgoCD UI for more than a few seconds.
 {{- end}}
 
 {{- end }}


### PR DESCRIPTION

## Description

Avoid displaying the "Sync from PR Branch" checkbox for new applications and use native markdown "alerts".

* Create a new function to check if all application in a PR are new.
* Write tests for new function
* Rename `HasSyncableComponents` to `DisplaySyncBranchCheckBox` to better match its new usage.
* Switch from Emoji based annotation to GH markdown "alerts"




Please provide a meaningful description of what this change will do, or is for. Bonus points for including links to related issues, other PRs, or technical references.

Note that by _not_ including a description, you are asking reviewers to do extra work to understand the context of this change, which may lead to your PR taking much longer to review, or result in it not being reviewed at all.

## Type of Change

- [x] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](https://github.com/wayfair-incubator/telefonistka/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
