### PR TITLE
SD-838: fix panic

### DIFF
--- a/internal/pkg/argocd/argocd.go
+++ b/internal/pkg/argocd/argocd.go
@@ -474,7 +474,7 @@ func generateDiffOfAComponent(ctx context.Context, commentDiff bool, componentPa
 		app, err := ac.app.Get(ctx, &appNameQuery)
 		if err != nil {
 			componentDiffResult.DiffError = err
-			log.Errorf("Error getting app(HardRefresh) %s: %v", appNameQuery.Name, err)
+			log.Errorf("Error getting app(HardRefresh) %v: %v", appNameQuery.Name, err)
 			return componentDiffResult
 		}
 		log.Debugf("Got ArgoCD app %s", app.Name)


### PR DESCRIPTION
## Description

See https://commercetools.atlassian.net/browse/SD-838 for details.

Fixes a potential panic in the code that has recently been observed.

```
The change [1] introduced a potential panic as it is trying to log the
app name when a failure happens, but the app variable is overridden
during such a failure and is thus nil.

This results in the following panic.

    panic: runtime error: invalid memory address or nil pointer dereference
    [signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x20ddccb]

    goroutine 367 [running]:
    internal/pkg/argocd.generateDiffOfAComponent()
	    internal/pkg/argocd/argocd.go:477
    internal/pkg/argocd.GenerateDiffOfChangedComponents()
	    internal/pkg/argocd/argocd.go:561
    internal/pkg/githubapi.HandlePREvent()
	    internal/pkg/githubapi/github.go:161
    internal/pkg/githubapi.handleEvent()
	    internal/pkg/githubapi/github.go:382
    created by internal/pkg/githubapi.ReciveWebhook
	    internal/pkg/githubapi/github.go:322

By instead using the name from the query constructed prior, the panic
should be avoided.

[1] https://github.com/commercetools/telefonistka/commit/adbd91328b2edce48ee4607f101ecb2b6528d77b
```

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)