### PR TITLE
SD-781: Telefonistka wrongly reports "Error" when deploying from a PR branch with auto-sync on

### DIFF
--- a/internal/pkg/argocd/argocd.go
+++ b/internal/pkg/argocd/argocd.go
@@ -58,6 +58,7 @@ type DiffResult struct {
 	HasDiff                  bool
 	DiffError                error
 	AppWasTemporarilyCreated bool
+	AppSyncedFromPRBranch    bool
 }
 
 // Mostly copied from  https://github.com/argoproj/argo-cd/blob/4f6a8dce80f0accef7ed3b5510e178a6b398b331/cmd/argocd/commands/app.go#L1255C6-L1338
@@ -483,7 +484,9 @@ func generateDiffOfAComponent(ctx context.Context, commentDiff bool, componentPa
 	componentDiffResult.ArgoCdAppURL = fmt.Sprintf("%s/applications/%s", argoSettings.URL, app.Name)
 
 	if app.Spec.Source.TargetRevision == prBranch && app.Spec.SyncPolicy.Automated != nil {
-		componentDiffResult.DiffError = fmt.Errorf("App %s already has revision %s as Source Target Revision and autosync is on, skipping diff calculation", app.Name, prBranch)
+		componentDiffResult.DiffError = nil
+		componentDiffResult.AppSyncedFromPRBranch = true
+
 		return componentDiffResult
 	}
 

--- a/internal/pkg/githubapi/github.go
+++ b/internal/pkg/githubapi/github.go
@@ -115,10 +115,11 @@ func shouldSyncBranchCheckBoxBeDisplayed(componentPathList []string, allowSyncfr
 		if !isSyncFromBranchAllowedForThisPath(allowSyncfromBranchPathRegex, componentPath) {
 			continue
 		}
+
 		// Then we check the relevant app is not new, temporary app.
 		// We don't support syncing new apps from branches
 		for _, diffOfChangedComponent := range diffOfChangedComponents {
-			if diffOfChangedComponent.ComponentPath == componentPath && !diffOfChangedComponent.AppWasTemporarilyCreated {
+			if diffOfChangedComponent.ComponentPath == componentPath && !diffOfChangedComponent.AppWasTemporarilyCreated && !diffOfChangedComponent.AppSyncedFromPRBranch {
 				return true
 			}
 		}

--- a/internal/pkg/githubapi/github_test.go
+++ b/internal/pkg/githubapi/github_test.go
@@ -314,6 +314,17 @@ func TestShouldSyncBranchCheckBoxBeDisplayed(t *testing.T) {
 			},
 			expected: false,
 		},
+		"App synced from branch": {
+			componentPathList:            []string{"workspace/app1"},
+			allowSyncfromBranchPathRegex: `^workspace/.*$`,
+			diffOfChangedComponents: []argocd.DiffResult{
+				{
+					AppSyncedFromPRBranch: true,
+					ComponentPath:         "workspace/app1",
+				},
+			},
+			expected: false,
+		},
 		"Existing App": {
 			componentPathList:            []string{"workspace/app1"},
 			allowSyncfromBranchPathRegex: `^workspace/.*$`,
@@ -326,7 +337,7 @@ func TestShouldSyncBranchCheckBoxBeDisplayed(t *testing.T) {
 			expected: true,
 		},
 		"Mixed New and Existing Apps": {
-			componentPathList:            []string{"workspace/app1", "workspace/app2"},
+			componentPathList:            []string{"workspace/app1", "workspace/app2", "workspace/app3"},
 			allowSyncfromBranchPathRegex: `^workspace/.*$`,
 			diffOfChangedComponents: []argocd.DiffResult{
 				{
@@ -336,6 +347,10 @@ func TestShouldSyncBranchCheckBoxBeDisplayed(t *testing.T) {
 				{
 					AppWasTemporarilyCreated: true,
 					ComponentPath:            "workspace/app2",
+				},
+				{
+					AppSyncedFromPRBranch: true,
+					ComponentPath:         "workspace/app3",
 				},
 			},
 			expected: true,

--- a/templates/argoCD-diff-pr-comment-concise.gotmpl
+++ b/templates/argoCD-diff-pr-comment-concise.gotmpl
@@ -26,6 +26,11 @@ Diff of ArgoCD applications(⚠️ concise view, full diff didn't fit GH comment
 
 </details>
 {{- else }}
+{{ if  $appDiffResult.AppSyncedFromPRBranch }}
+> [!NOTE]
+> The app already has this branch set as the source target revision, and autosync is enabled. Diff calculation was skipped.
+{{- else }}
+
 No diff 🤷
 {{- end}}
 {{if $appDiffResult.AppWasTemporarilyCreated }}
@@ -34,6 +39,7 @@ No diff 🤷
 > It will not be present in ArgoCD UI for more than a few seconds.
 {{- end}}
 
+{{- end }}
 {{- end }}
 
 {{- end }}

--- a/templates/argoCD-diff-pr-comment.gotmpl
+++ b/templates/argoCD-diff-pr-comment.gotmpl
@@ -38,6 +38,11 @@ Please check the App Conditions of <img src="https://argo-cd.readthedocs.io/en/s
 
 </details>
 {{- else }}
+{{ if  $appDiffResult.AppSyncedFromPRBranch }}
+> [!NOTE]
+> The app already has this branch set as the source target revision, and autosync is enabled. Diff calculation was skipped.
+{{- else }}
+
 No diff 🤷
 {{- end}}
 {{if $appDiffResult.AppWasTemporarilyCreated }}
@@ -46,6 +51,7 @@ No diff 🤷
 > It will not be present in ArgoCD UI for more than a few seconds.
 {{- end}}
 
+{{- end }}
 {{- end }}
 
 {{- end }}


### PR DESCRIPTION
## Description

1. User opens a pr 
2. They set the application’s object source to pr branch for an application with autosync enabled
3. They push another commit 

Outcome:
They see an a failed 🔴  telefonistka run with an error like the following: 
> :warning: :warning: Error getting diff from ArgoCD …
> ```
> App <x> already has revision <branch> as Source Target Revision and autosync is on, skipping diff calculation
> ```

Instead we want to replace the Failing status with Passing status, the Error message with Info message, and avoid showing the `Set ArgoCD apps Target Rervision to…`

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](https://github.com/wayfair-incubator/telefonistka/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
