### PR TITLE
SD-853 increase timeout

### DIFF
--- a/internal/pkg/githubapi/github.go
+++ b/internal/pkg/githubapi/github.go
@@ -365,7 +365,7 @@ func ReciveWebhook(r *http.Request, mainGhClientCache *lru.Cache[string, GhClien
 func handleEvent(eventPayloadInterface interface{}, mainGhClientCache *lru.Cache[string, GhClientPair], prApproverGhClientCache *lru.Cache[string, GhClientPair], r *http.Request, payload []byte) {
 	// We don't use the request context as it might have a short deadline and we don't want to stop event handling based on that
 	// But we do want to stop the event handling after a certain point, so:
-	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 	var mainGithubClientPair GhClientPair
 	var approverGithubClientPair GhClientPair


### PR DESCRIPTION
```
Calculating diffs on promotion pull requests like [1] fails since the context is timing out and processing is aborted. This is evident from logs.

    Error getting manifests for app ..., revision ...:
	rpc error: code = DeadlineExceeded desc = context deadline exceeded"
    Error generating diff for component ...:
	rpc error: code = DeadlineExceeded desc = context deadline exceeded"
    Handling of PR event failed: err=getting diff information:
	rpc error: code = DeadlineExceeded desc = context deadline exceeded\n" ...

Increasing the timeout is a short-term fix to mitigate the issue and allow users to get the diff while additional investigation is done to figure out how we can address this better long-term.

[1] https://github.com/commercetools/k8s-gitops/pull/998
```

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](https://github.com/wayfair-incubator/telefonistka/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
