### PR TITLE
Trim '[bot]' suffix from botIdentity

### DIFF
--- a/internal/pkg/githubapi/github_graphql.go
+++ b/internal/pkg/githubapi/github_graphql.go
@@ -68,7 +68,7 @@ func MimizeStalePrComments(ghPrClientDetails GhPrClientDetails, githubGraphQlCli
 	if err != nil {
 		ghPrClientDetails.PrLogger.Errorf("Failed to minimize stale comments: err=%s\n", err)
 	}
-	bi := githubv4.String(botIdentity)
+	bi := githubv4.String(strings.TrimSuffix(botIdentity, "[bot]"))
 	for _, prComment := range getCommentNodeIdsQuery.Repository.PullRequest.Comments.Edges {
 		if !prComment.Node.IsMinimized && prComment.Node.Author.Login == bi {
 			if strings.Contains(string(prComment.Node.Body), "<!-- telefonistka_tag -->") {


### PR DESCRIPTION
## Description

Telefonistka wasn't minimizing its own previous comments. This is because the comment author and the commenter identity did not match. The commenter identity as returned by graphql had `[bot]` appended to the name, while the comment author did not. This is fixed by trimming the `[bot]` suffix from the identity before comparing it to the comment author.

tested: https://github.com/commercetools/k8s-manifests-poc/pull/327

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](https://github.com/wayfair-incubator/telefonistka/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
