### PR TITLE
monitoring PR handling failures.

### DIFF
--- a/cmd/telefonistka/server.go
+++ b/cmd/telefonistka/server.go
@@ -57,13 +57,7 @@ func serve() {
 	mainGhClientCache, _ := lru.New[string, githubapi.GhClientPair](128)
 	prApproverGhClientCache, _ := lru.New[string, githubapi.GhClientPair](128)
 
-	go func() {
-		for {
-			log.Debugf("Stale check runner")
-			githubapi.GetPrMetrics(mainGhClientCache)
-			time.Sleep(60 * time.Second) // TODO: make this configurable? GH API rate limits are a facor here
-		}
-	}()
+	go githubapi.MainGhMetricsLoop(mainGhClientCache)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/webhook", handleWebhook(githubWebhookSecret, mainGhClientCache, prApproverGhClientCache))

--- a/cmd/telefonistka/server.go
+++ b/cmd/telefonistka/server.go
@@ -61,7 +61,7 @@ func serve() {
 		for {
 			log.Debugf("Stale check runner")
 			githubapi.GetPrMetrics(mainGhClientCache)
-			time.Sleep(60 * time.Second) //TODO: make this configurable? GH API rate limits are a facor here
+			time.Sleep(60 * time.Second) // TODO: make this configurable? GH API rate limits are a facor here
 		}
 	}()
 

--- a/cmd/telefonistka/server.go
+++ b/cmd/telefonistka/server.go
@@ -57,6 +57,14 @@ func serve() {
 	mainGhClientCache, _ := lru.New[string, githubapi.GhClientPair](128)
 	prApproverGhClientCache, _ := lru.New[string, githubapi.GhClientPair](128)
 
+	go func() {
+		for {
+			log.Debugf("Stale check runner")
+			githubapi.GetPrMetrics(mainGhClientCache)
+			time.Sleep(60 * time.Second) //TODO: make this configurable? GH API rate limits are a facor here
+		}
+	}()
+
 	mux := http.NewServeMux()
 	mux.HandleFunc("/webhook", handleWebhook(githubWebhookSecret, mainGhClientCache, prApproverGhClientCache))
 	mux.Handle("/metrics", promhttp.Handler())

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -6,6 +6,10 @@
 |telefonistka_github_github_rest_api_client_rate_remaining|gauge|The number of remaining requests the client can make this hour||
 |telefonistka_github_github_rest_api_client_rate_limit|gauge|The number of requests per hour the client is currently limited to||
 |telefonistka_webhook_server_webhook_hits_total|counter|The total number of validated webhook hits|`parsing`|
+|telefonistka_github_open_prs|gauge|The number of open PRs|`repo_slug`|
+|telefonistka_github_open_promotion_prs|gauge|The number of open promotion PRs|`repo_slug`|
+|telefonistka_github_open_prs_with_pending_telefonistka_checks|gauge|The number of open PRs with pending Telefonistka checks(excluding PRs with very recent commits)|`repo_slug`|
+|telefonistka_github_commit_status_updates_total|counter|The total number of commit status updates, and their status (success/pending/failure)|`repo_slug`, `status`|
 
 Example metrics snippet:
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -11,6 +11,9 @@
 |telefonistka_github_open_prs_with_pending_telefonistka_checks|gauge|The number of open PRs with pending Telefonistka checks(excluding PRs with very recent commits)|`repo_slug`|
 |telefonistka_github_commit_status_updates_total|counter|The total number of commit status updates, and their status (success/pending/failure)|`repo_slug`, `status`|
 
+> [!NOTE]  
+> telefonistka_github_*_prs metrics are only supported on installtions that uses GitHub App authentication as it provides an easy way to query the relevant GH repos.
+
 Example metrics snippet:
 
 ```text

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -33,4 +33,20 @@ telefonistka_github_github_rest_api_client_rate_remaining 99668
 # HELP telefonistka_webhook_server_webhook_hits_total The total number of validated webhook hits
 # TYPE telefonistka_webhook_server_webhook_hits_total counter
 telefonistka_webhook_server_webhook_hits_total{parsing="successful"} 8
+# HELP telefonistka_github_commit_status_updates_total The total number of commit status updates, and their status (success/pending/failure)
+# TYPE telefonistka_github_commit_status_updates_total counter
+telefonistka_github_commit_status_updates_total{repo_slug="foo/bar2",status="error"} 1
+telefonistka_github_commit_status_updates_total{repo_slug="foo/bar2",status="pending"} 1
+# HELP telefonistka_github_open_promotion_prs The total number of open PRs with promotion label
+# TYPE telefonistka_github_open_promotion_prs gauge
+telefonistka_github_open_promotion_prs{repo_slug="foo/bar1"} 0
+telefonistka_github_open_promotion_prs{repo_slug="foo/bar2"} 10
+# HELP telefonistka_github_open_prs The total number of open PRs
+# TYPE telefonistka_github_open_prs gauge
+telefonistka_github_open_prs{repo_slug="foo/bar1"} 0
+telefonistka_github_open_prs{repo_slug="foo/bar2"} 21
+# HELP telefonistka_github_open_prs_with_pending_telefonistka_checks The total number of open PRs with pending Telefonistka checks(excluding PRs with very recent commits)
+# TYPE telefonistka_github_open_prs_with_pending_telefonistka_checks gauge
+telefonistka_github_open_prs_with_pending_telefonistka_checks{repo_slug="foo/bar1"} 0
+telefonistka_github_open_prs_with_pending_telefonistka_checks{repo_slug="foo/bar2"} 0
 ```

--- a/internal/pkg/githubapi/github.go
+++ b/internal/pkg/githubapi/github.go
@@ -146,6 +146,7 @@ func HandlePREvent(eventPayload *github.PullRequestEvent, ghPrClientDetails GhPr
 	defer func() {
 		if err != nil {
 			SetCommitStatus(ghPrClientDetails, "error")
+			prom.IncPrHandleFailuresCounter(ghPrClientDetails.Owner + "/" + ghPrClientDetails.Repo)
 			return
 		}
 		SetCommitStatus(ghPrClientDetails, "success")

--- a/internal/pkg/githubapi/github.go
+++ b/internal/pkg/githubapi/github.go
@@ -146,7 +146,6 @@ func HandlePREvent(eventPayload *github.PullRequestEvent, ghPrClientDetails GhPr
 	defer func() {
 		if err != nil {
 			SetCommitStatus(ghPrClientDetails, "error")
-			prom.IncPrHandleFailuresCounter(ghPrClientDetails.Owner + "/" + ghPrClientDetails.Repo)
 			return
 		}
 		SetCommitStatus(ghPrClientDetails, "success")
@@ -877,6 +876,8 @@ func SetCommitStatus(ghPrClientDetails GhPrClientDetails, state string) {
 
 	_, resp, err := ghPrClientDetails.GhClientPair.v3Client.Repositories.CreateStatus(ctx, ghPrClientDetails.Owner, ghPrClientDetails.Repo, ghPrClientDetails.PrSHA, commitStatus)
 	prom.InstrumentGhCall(resp)
+	repoSlug := ghPrClientDetails.Owner + "/" + ghPrClientDetails.Repo
+	prom.IncCommitStatusUpdateCounter(repoSlug, state)
 	if err != nil {
 		ghPrClientDetails.PrLogger.Errorf("Failed to set commit status: err=%s\n%v", err, resp)
 	}

--- a/internal/pkg/githubapi/pr_metrics.go
+++ b/internal/pkg/githubapi/pr_metrics.go
@@ -16,9 +16,9 @@ const (
 )
 
 func MainGhMetricsLoop(mainGhClientCache *lru.Cache[string, GhClientPair]) {
-	for {
+	for t := range time.Tick(metricRefreshTime) {
+		log.Debugf("Updating pr metrics at %v", t)
 		getPrMetrics(mainGhClientCache)
-		time.Sleep(metricRefreshTime)
 	}
 }
 

--- a/internal/pkg/githubapi/pr_metrics.go
+++ b/internal/pkg/githubapi/pr_metrics.go
@@ -81,8 +81,8 @@ func isPrStalePending(commitStatuses *github.CombinedStatus, timeToDefineStale t
 	return false
 }
 
-// getPrMetrics itterates through all clients , gets all repos and then all PRs and calculates metrics
-// This assumes Telefonsitka uses a GitHub App style of authentication as it uses the Apps.ListRepos call
+// getPrMetrics iterates through all clients , gets all repos and then all PRs and calculates metrics
+// getPrMetrics assumes Telefonsitka uses a GitHub App style of authentication as it uses the Apps.ListRepos call
 // When using  personal access token authentication, Telefonistka is unaware of the "relevant" repos (at least it get a webhook from them).
 func getPrMetrics(mainGhClientCache *lru.Cache[string, GhClientPair]) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)

--- a/internal/pkg/githubapi/pr_metrics.go
+++ b/internal/pkg/githubapi/pr_metrics.go
@@ -1,0 +1,88 @@
+package githubapi
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/go-github/v62/github"
+	lru "github.com/hashicorp/golang-lru/v2"
+	log "github.com/sirupsen/logrus"
+	prom "github.com/wayfair-incubator/telefonistka/internal/pkg/prometheus"
+)
+
+const (
+	minutesToDfineStale = 20
+)
+
+func getRepoPrMetrics(ctx context.Context, ghClient GhClientPair, repo *github.Repository) (prWithStakeChecks int, openPRs int, openPromotionPrs int, err error) {
+
+	log.Debugf("Checking repo %s", repo.GetName())
+	ghOwner := repo.GetOwner().GetLogin()
+	prListOpts := &github.PullRequestListOptions{
+		State: "open",
+	}
+	prs := []*github.PullRequest{}
+
+	// paginate through PRs, there might be lot of them.
+	for {
+		perPagePrs, resp, err := ghClient.v3Client.PullRequests.List(ctx, ghOwner, repo.GetName(), prListOpts)
+		_ = prom.InstrumentGhCall(resp)
+		if err != nil {
+			log.Errorf("error getting PRs for %s/%s: %v", ghOwner, repo.GetName(), err)
+		}
+		prs = append(prs, perPagePrs...)
+		if resp.NextPage == 0 {
+			break
+		}
+		prListOpts.Page = resp.NextPage
+	}
+
+	for _, pr := range prs {
+		if DoesPrHasLabel(pr.Labels, "promotion") {
+			openPromotionPrs++
+		}
+		log.Debugf("Checking PR %d", pr.GetNumber())
+		commitStatuses, resp, err := ghClient.v3Client.Repositories.GetCombinedStatus(ctx, ghOwner, repo.GetName(), pr.GetHead().GetSHA(), nil)
+		_ = prom.InstrumentGhCall(resp)
+		if err != nil {
+			log.Errorf("error getting statuses for %s/%s/%d: %v", ghOwner, repo.GetName(), pr.GetNumber(), err)
+			continue
+		}
+		for _, status := range commitStatuses.Statuses {
+			if *status.Context == "telefonistka" &&
+				*status.State == "pending" &&
+				status.UpdatedAt.GetTime().Before(time.Now().Add(-time.Minute*minutesToDfineStale)) {
+				log.Debugf("Adding status %s-%v-%s !!!", *status.Context, status.UpdatedAt.GetTime(), *status.State)
+				prWithStakeChecks++
+			} else {
+				log.Debugf("Ignoring status %s-%v-%s", *status.Context, status.UpdatedAt.GetTime(), *status.State)
+			}
+
+		}
+
+	}
+	openPRs = len(prs)
+
+	return
+}
+
+// GetPrMetrics counts the number of pending checks that are older than 20 minutes
+func GetPrMetrics(mainGhClientCache *lru.Cache[string, GhClientPair]) {
+	ctx := context.Background() // TODO!!!!
+
+	for _, ghOwner := range mainGhClientCache.Keys() {
+		log.Debugf("Checking gh Owner %s", ghOwner)
+		ghClient, _ := mainGhClientCache.Get(ghOwner)
+		repos, resp, err := ghClient.v3Client.Apps.ListRepos(ctx, nil)
+		_ = prom.InstrumentGhCall(resp)
+		if err != nil {
+			log.Errorf("error getting repos for %s: %v", ghOwner, err)
+			continue
+		}
+		for _, repo := range repos.Repositories {
+			stalePendingChecks, openPrs, promotionPrs, _ := getRepoPrMetrics(ctx, ghClient, repo)
+			prom.PublishPrMetrics(openPrs, promotionPrs, stalePendingChecks, repo.GetFullName())
+		}
+
+	}
+}

--- a/internal/pkg/githubapi/pr_metrics.go
+++ b/internal/pkg/githubapi/pr_metrics.go
@@ -22,7 +22,7 @@ func MainGhMetricsLoop(mainGhClientCache *lru.Cache[string, GhClientPair]) {
 	}
 }
 
-func getRepoPrMetrics(ctx context.Context, ghClient GhClientPair, repo *github.Repository) (prWithStakeChecks int, openPRs int, openPromotionPrs int, err error) {
+func getRepoPrMetrics(ctx context.Context, ghClient GhClientPair, repo *github.Repository) (prWithStaleChecks int, openPRs int, openPromotionPrs int, err error) {
 	log.Debugf("Checking repo %s", repo.GetName())
 	ghOwner := repo.GetOwner().GetLogin()
 	prListOpts := &github.PullRequestListOptions{
@@ -57,7 +57,7 @@ func getRepoPrMetrics(ctx context.Context, ghClient GhClientPair, repo *github.R
 			continue
 		}
 		if isPrStalePending(commitStatuses, timeToDefineStale) {
-			prWithStakeChecks++
+			prWithStaleChecks++
 		}
 	}
 	openPRs = len(prs)

--- a/internal/pkg/githubapi/pr_metrics.go
+++ b/internal/pkg/githubapi/pr_metrics.go
@@ -15,7 +15,6 @@ const (
 )
 
 func getRepoPrMetrics(ctx context.Context, ghClient GhClientPair, repo *github.Repository) (prWithStakeChecks int, openPRs int, openPromotionPrs int, err error) {
-
 	log.Debugf("Checking repo %s", repo.GetName())
 	ghOwner := repo.GetOwner().GetLogin()
 	prListOpts := &github.PullRequestListOptions{
@@ -57,9 +56,7 @@ func getRepoPrMetrics(ctx context.Context, ghClient GhClientPair, repo *github.R
 			} else {
 				log.Debugf("Ignoring status %s-%v-%s", *status.Context, status.UpdatedAt.GetTime(), *status.State)
 			}
-
 		}
-
 	}
 	openPRs = len(prs)
 
@@ -83,6 +80,5 @@ func GetPrMetrics(mainGhClientCache *lru.Cache[string, GhClientPair]) {
 			stalePendingChecks, openPrs, promotionPrs, _ := getRepoPrMetrics(ctx, ghClient, repo)
 			prom.PublishPrMetrics(openPrs, promotionPrs, stalePendingChecks, repo.GetFullName())
 		}
-
 	}
 }

--- a/internal/pkg/githubapi/pr_metrics.go
+++ b/internal/pkg/githubapi/pr_metrics.go
@@ -59,7 +59,6 @@ func getRepoPrMetrics(ctx context.Context, ghClient GhClientPair, repo *github.R
 
 // isPrStalePending checks if the a combinedStatus has a "telefonistka" context pending status that is older than minutesToDefineStale and is in pending state
 func isPrStalePending(commitStatuses *github.CombinedStatus, minutesToDefineStale int) bool {
-
 	staleDuration := time.Duration(minutesToDefineStale) * time.Minute * -1
 
 	for _, status := range commitStatuses.Statuses {

--- a/internal/pkg/githubapi/pr_metrics.go
+++ b/internal/pkg/githubapi/pr_metrics.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	minutesToDfineStale = 20
+	minutesToDefineStale = 20
 )
 
 func getRepoPrMetrics(ctx context.Context, ghClient GhClientPair, repo *github.Repository) (prWithStakeChecks int, openPRs int, openPromotionPrs int, err error) {
@@ -48,7 +48,7 @@ func getRepoPrMetrics(ctx context.Context, ghClient GhClientPair, repo *github.R
 			log.Errorf("error getting statuses for %s/%s/%d: %v", ghOwner, repo.GetName(), pr.GetNumber(), err)
 			continue
 		}
-		if isPrStalePending(commitStatuses, minutesToDfineStale) {
+		if isPrStalePending(commitStatuses, minutesToDefineStale) {
 			prWithStakeChecks++
 		}
 	}
@@ -57,10 +57,10 @@ func getRepoPrMetrics(ctx context.Context, ghClient GhClientPair, repo *github.R
 	return
 }
 
-// isPrStalePending checks if the a combinedStatus has a "telefonistka" context pending status that is older than minutesToDfineStale and is in pending state
-func isPrStalePending(commitStatuses *github.CombinedStatus, minutesToDfineStale int) bool {
+// isPrStalePending checks if the a combinedStatus has a "telefonistka" context pending status that is older than minutesToDefineStale and is in pending state
+func isPrStalePending(commitStatuses *github.CombinedStatus, minutesToDefineStale int) bool {
 
-	staleDuration := time.Duration(minutesToDfineStale) * time.Minute * -1
+	staleDuration := time.Duration(minutesToDefineStale) * time.Minute * -1
 
 	for _, status := range commitStatuses.Statuses {
 		if *status.Context == "telefonistka" &&

--- a/internal/pkg/githubapi/pr_metrics_test.go
+++ b/internal/pkg/githubapi/pr_metrics_test.go
@@ -1,0 +1,90 @@
+package githubapi
+
+// @Title
+// @Description
+// @Author
+// @Update
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-github/v62/github"
+)
+
+func TestIsPrStalePending(t *testing.T) {
+	minutesToDfineStale := 15
+
+	currentTime := time.Now()
+	tests := map[string]struct {
+		input  github.CombinedStatus
+		result bool
+	}{
+		"All Success": {
+			input: github.CombinedStatus{
+				Statuses: []*github.RepoStatus{
+					{
+						State:   github.String("success"),
+						Context: github.String("telefonistka"),
+						UpdatedAt: &github.Timestamp{
+							Time: currentTime.Add(-10 * time.Minute),
+						},
+					},
+					{
+						State:   github.String("success"),
+						Context: github.String("circleci"),
+						UpdatedAt: &github.Timestamp{
+							Time: currentTime.Add(-10 * time.Minute),
+						},
+					},
+					{
+						State:   github.String("success"),
+						Context: github.String("foobar"),
+						UpdatedAt: &github.Timestamp{
+							Time: currentTime.Add(-10 * time.Minute),
+						},
+					},
+				},
+			},
+			result: false,
+		},
+		"Pending but not stale": {
+			input: github.CombinedStatus{
+				Statuses: []*github.RepoStatus{
+					{
+						State:   github.String("pending"),
+						Context: github.String("telefonistka"),
+						UpdatedAt: &github.Timestamp{
+							Time: currentTime.Add(-1 * time.Minute),
+						},
+					},
+				},
+			},
+			result: false,
+		},
+
+		"Pending and stale": {
+			input: github.CombinedStatus{
+				Statuses: []*github.RepoStatus{
+					{
+						State:   github.String("pending"),
+						Context: github.String("telefonistka"),
+						UpdatedAt: &github.Timestamp{
+							Time: currentTime.Add(-20 * time.Minute),
+						},
+					},
+				},
+			},
+			result: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := isPrStalePending(&tc.input, minutesToDfineStale)
+			if result != tc.result {
+				t.Errorf("(%s)Expected %v, got %v", name, tc.result, result)
+			}
+		})
+	}
+
+}

--- a/internal/pkg/githubapi/pr_metrics_test.go
+++ b/internal/pkg/githubapi/pr_metrics_test.go
@@ -80,7 +80,10 @@ func TestIsPrStalePending(t *testing.T) {
 	}
 
 	for name, tc := range tests {
+		name := name
+		tc := tc
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			result := isPrStalePending(&tc.input, timeToDefineStale)
 			if result != tc.result {
 				t.Errorf("(%s)Expected %v, got %v", name, tc.result, result)

--- a/internal/pkg/githubapi/pr_metrics_test.go
+++ b/internal/pkg/githubapi/pr_metrics_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestIsPrStalePending(t *testing.T) {
-	minutesToDefineStale := 15
+	timeToDefineStale := 15 * time.Minute
 
 	currentTime := time.Now()
 	tests := map[string]struct {
@@ -80,7 +80,7 @@ func TestIsPrStalePending(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			result := isPrStalePending(&tc.input, minutesToDefineStale)
+			result := isPrStalePending(&tc.input, timeToDefineStale)
 			if result != tc.result {
 				t.Errorf("(%s)Expected %v, got %v", name, tc.result, result)
 			}

--- a/internal/pkg/githubapi/pr_metrics_test.go
+++ b/internal/pkg/githubapi/pr_metrics_test.go
@@ -1,9 +1,5 @@
 package githubapi
 
-// @Title
-// @Description
-// @Author
-// @Update
 import (
 	"testing"
 	"time"

--- a/internal/pkg/githubapi/pr_metrics_test.go
+++ b/internal/pkg/githubapi/pr_metrics_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestIsPrStalePending(t *testing.T) {
+	t.Parallel()
 	timeToDefineStale := 15 * time.Minute
 
 	currentTime := time.Now()
@@ -86,5 +87,4 @@ func TestIsPrStalePending(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/internal/pkg/githubapi/pr_metrics_test.go
+++ b/internal/pkg/githubapi/pr_metrics_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestIsPrStalePending(t *testing.T) {
-	minutesToDfineStale := 15
+	minutesToDefineStale := 15
 
 	currentTime := time.Now()
 	tests := map[string]struct {
@@ -80,7 +80,7 @@ func TestIsPrStalePending(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			result := isPrStalePending(&tc.input, minutesToDfineStale)
+			result := isPrStalePending(&tc.input, minutesToDefineStale)
 			if result != tc.result {
 				t.Errorf("(%s)Expected %v, got %v", name, tc.result, result)
 			}

--- a/internal/pkg/prometheus/prometheus.go
+++ b/internal/pkg/prometheus/prometheus.go
@@ -60,12 +60,12 @@ var (
 		Subsystem: "github",
 	}, []string{"repo_slug"})
 
-	prHandleFailuresCounter = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name:      "pr_handle_failures_total",
-		Help:      "The total number of PR handling failures",
+	commitStatusUpdates = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name:      "commit_status_updates_total",
+		Help:      "The total number of commit status updates, and their status (success/pending/failure)",
 		Namespace: "telefonistka",
-		Subsystem: "core",
-	}, []string{"repo_slug"})
+		Subsystem: "github",
+	}, []string{"repo_slug", "status"})
 
 	whUpstreamRequestsCountVec = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name:      "upstream_requests_total",
@@ -75,8 +75,11 @@ var (
 	}, []string{"status", "method", "url"})
 )
 
-func IncPrHandleFailuresCounter(repoSlug string) {
-	prHandleFailuresCounter.With(prometheus.Labels{"repo_slug": repoSlug}).Inc()
+func IncCommitStatusUpdateCounter(repoSlug string, status string) {
+	commitStatusUpdates.With(prometheus.Labels{
+		"repo_slug": repoSlug,
+		"status":    status,
+	}).Inc()
 }
 
 func PublishPrMetrics(openPrs int, openPromPRs int, openPrsWithPendingChecks int, repoSlug string) {

--- a/internal/pkg/prometheus/prometheus.go
+++ b/internal/pkg/prometheus/prometheus.go
@@ -10,6 +10,12 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
+type PrCounters struct {
+	OpenPrs           int
+	OpenPromotionPrs  int
+	PrWithStaleChecks int
+}
+
 var (
 	webhookHitsVec = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name:      "webhook_hits_total",
@@ -82,13 +88,13 @@ func IncCommitStatusUpdateCounter(repoSlug string, status string) {
 	}).Inc()
 }
 
-func PublishPrMetrics(openPrs int, openPromPRs int, openPrsWithPendingChecks int, repoSlug string) {
+func PublishPrMetrics(pc PrCounters, repoSlug string) {
 	metricLables := prometheus.Labels{
 		"repo_slug": repoSlug,
 	}
-	ghOpenPrsGauge.With(metricLables).Set(float64(openPrs))
-	ghOpenPromotionPrsGauge.With(metricLables).Set(float64(openPromPRs))
-	ghOpenPrsWithPendingCheckGauge.With(metricLables).Set(float64(openPrsWithPendingChecks))
+	ghOpenPrsGauge.With(metricLables).Set(float64(pc.OpenPrs))
+	ghOpenPromotionPrsGauge.With(metricLables).Set(float64(pc.OpenPromotionPrs))
+	ghOpenPrsWithPendingCheckGauge.With(metricLables).Set(float64(pc.PrWithStaleChecks))
 }
 
 // This function instrument Webhook hits and parsing of their content


### PR DESCRIPTION
This PR adds a few metrics to Telefonistka process

## Description

```
Name:      "open_prs",
Help:      "The total number of open PRs",
```
Note: Just a metric to track activity in repo.

```
Name:      "open_promotion_prs",
Help:      "The total number of open PRs with promotion label",
```
Note: Could be used to check if we need to enforce merging/closing stale promotion PRs

```
Name:      "open_prs_with_pending_telefonistka_checks",
Help:      "The total number of open PRs with pending Telefonistka checks(excluding PRs with very recent commits)",
```
Note: those represent cases the Telefonsitka totaly failed, not even marking the checks as fialed

```
Name:      "commit_status_updates_total",
Help:      "The total number of commit status updates, and their status (success/pending/failure)",

```
We can use this track failure telefonistika is aware of

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](https://github.com/wayfair-incubator/telefonistka/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
