### PR TITLE
Sd 854 parallelize fetching of argocd diff in telefonistka

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /telefonistka
 vendor/
 internal/pkg/mocks/argocd_settings.go
+internal/pkg/mocks/argocd_project.go

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /telefonistka
 vendor/
+internal/pkg/mocks/argocd_settings.go

--- a/cmd/telefonistka/server.go
+++ b/cmd/telefonistka/server.go
@@ -10,7 +10,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/wayfair-incubator/telefonistka/internal/pkg/argocd"
 	"github.com/wayfair-incubator/telefonistka/internal/pkg/githubapi"
 )
 
@@ -57,12 +56,6 @@ func serve() {
 	// mainGhClientCache := map[string]githubapi.GhClientPair{} //GH apps use a per-account/org client
 	mainGhClientCache, _ := lru.New[string, githubapi.GhClientPair](128)
 	prApproverGhClientCache, _ := lru.New[string, githubapi.GhClientPair](128)
-
-	// init argoclients
-	err := argocd.InitArgoClients()
-	if err != nil {
-		log.Fatalf("error initializing argo clients: %v", err)
-	}
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/webhook", handleWebhook(githubWebhookSecret, mainGhClientCache, prApproverGhClientCache))

--- a/cmd/telefonistka/server.go
+++ b/cmd/telefonistka/server.go
@@ -10,6 +10,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/wayfair-incubator/telefonistka/internal/pkg/argocd"
 	"github.com/wayfair-incubator/telefonistka/internal/pkg/githubapi"
 )
 
@@ -56,6 +57,12 @@ func serve() {
 	// mainGhClientCache := map[string]githubapi.GhClientPair{} //GH apps use a per-account/org client
 	mainGhClientCache, _ := lru.New[string, githubapi.GhClientPair](128)
 	prApproverGhClientCache, _ := lru.New[string, githubapi.GhClientPair](128)
+
+	// init argoclients
+	err := argocd.InitArgoClients()
+	if err != nil {
+		log.Fatalf("error initializing argo clients: %v", err)
+	}
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/webhook", handleWebhook(githubWebhookSecret, mainGhClientCache, prApproverGhClientCache))

--- a/internal/pkg/argocd/argocd.go
+++ b/internal/pkg/argocd/argocd.go
@@ -33,15 +33,6 @@ import (
 // ctxLines is the number of context lines used in application diffs.
 const ctxLines = 10
 
-// replace in testing
-var InitArgoClients = func() (argoCdClients, error) {
-	argoClients, err := createArgoCdClients()
-	if err != nil {
-		return argoCdClients{}, fmt.Errorf("error creating ArgoCD clients: %w", err)
-	}
-	return argoClients, nil
-}
-
 type argoCdClients struct {
 	app     application.ApplicationServiceClient
 	project projectpkg.ProjectServiceClient

--- a/internal/pkg/argocd/argocd.go
+++ b/internal/pkg/argocd/argocd.go
@@ -558,7 +558,7 @@ func GenerateDiffOfChangedComponents(ctx context.Context, componentsToDiff map[s
 		return false, true, nil, err
 	}
 
-	diffResult := make(chan DiffResult, len(componentsToDiff))
+	diffResult := make(chan DiffResult)
 	for componentPath, shouldIDiff := range componentsToDiff {
 		go func(componentPath string, shouldDiff bool) {
 			diffResult <- generateDiffOfAComponent(ctx, shouldIDiff, componentPath, prBranch, repo, argoClients, argoSettings, useSHALabelForArgoDicovery, createTempAppObjectFromNewApps)

--- a/internal/pkg/argocd/argocd.go
+++ b/internal/pkg/argocd/argocd.go
@@ -172,7 +172,7 @@ func getEnv(key, fallback string) string {
 	return fallback
 }
 
-func createArgoCdClients() (ac argoCdClients, err error) {
+func CreateArgoCdClients() (ac argoCdClients, err error) {
 	plaintext, _ := strconv.ParseBool(getEnv("ARGOCD_PLAINTEXT", "false"))
 	insecure, _ := strconv.ParseBool(getEnv("ARGOCD_INSECURE", "false"))
 
@@ -320,7 +320,7 @@ func findArgocdApp(ctx context.Context, componentPath string, repo string, appCl
 func SetArgoCDAppRevision(ctx context.Context, componentPath string, revision string, repo string, useSHALabelForArgoDicovery bool) error {
 	var foundApp *argoappv1.Application
 	var err error
-	ac, err := createArgoCdClients()
+	ac, err := CreateArgoCdClients()
 	if err != nil {
 		return fmt.Errorf("Error creating ArgoCD clients: %w", err)
 	}

--- a/internal/pkg/argocd/argocd.go
+++ b/internal/pkg/argocd/argocd.go
@@ -554,9 +554,6 @@ func generateDiffOfAComponent(ctx context.Context, commentDiff bool, componentPa
 
 // GenerateDiffOfChangedComponents generates diff of changed components
 func GenerateDiffOfChangedComponents(ctx context.Context, componentsToDiff map[string]bool, prBranch string, repo string, useSHALabelForArgoDicovery bool, createTempAppObjectFromNewApps bool) (hasComponentDiff bool, hasComponentDiffErrors bool, diffResults []DiffResult, err error) {
-
-	// init argoclients
-	argoClients, err := InitArgoClients()
 	if err != nil {
 		log.Fatalf("error initializing argo clients: %v", err)
 	}

--- a/internal/pkg/argocd/argocd.go
+++ b/internal/pkg/argocd/argocd.go
@@ -553,7 +553,7 @@ func generateDiffOfAComponent(ctx context.Context, commentDiff bool, componentPa
 }
 
 // GenerateDiffOfChangedComponents generates diff of changed components
-func GenerateDiffOfChangedComponents(ctx context.Context, componentsToDiff map[string]bool, prBranch string, repo string, useSHALabelForArgoDicovery bool, createTempAppObjectFromNewApps bool) (hasComponentDiff bool, hasComponentDiffErrors bool, diffResults []DiffResult, err error) {
+func GenerateDiffOfChangedComponents(ctx context.Context, componentsToDiff map[string]bool, prBranch string, repo string, useSHALabelForArgoDicovery bool, createTempAppObjectFromNewApps bool, argoClients argoCdClients) (hasComponentDiff bool, hasComponentDiffErrors bool, diffResults []DiffResult, err error) {
 	if err != nil {
 		log.Fatalf("error initializing argo clients: %v", err)
 	}

--- a/internal/pkg/argocd/argocd.go
+++ b/internal/pkg/argocd/argocd.go
@@ -545,16 +545,12 @@ func generateDiffOfAComponent(ctx context.Context, commentDiff bool, componentPa
 
 // GenerateDiffOfChangedComponents generates diff of changed components
 func GenerateDiffOfChangedComponents(ctx context.Context, componentsToDiff map[string]bool, prBranch string, repo string, useSHALabelForArgoDicovery bool, createTempAppObjectFromNewApps bool, argoClients argoCdClients) (hasComponentDiff bool, hasComponentDiffErrors bool, diffResults []DiffResult, err error) {
-	if err != nil {
-		log.Fatalf("error initializing argo clients: %v", err)
-	}
-
 	hasComponentDiff = false
 	hasComponentDiffErrors = false
 
 	argoSettings, err := argoClients.setting.Get(ctx, &settings.SettingsQuery{})
 	if err != nil {
-		log.Errorf("Error getting ArgoCD settings: %v", err)
+		log.Errorf("error getting ArgoCD settings: %v", err)
 		return false, true, nil, err
 	}
 

--- a/internal/pkg/argocd/argocd.go
+++ b/internal/pkg/argocd/argocd.go
@@ -33,15 +33,13 @@ import (
 // ctxLines is the number of context lines used in application diffs.
 const ctxLines = 10
 
-var argoClients argoCdClients // replaced during tests
-
-func InitArgoClients() error {
-	var err error
-	argoClients, err = createArgoCdClients()
+// replace in testing
+var InitArgoClients = func() (argoCdClients, error) {
+	argoClients, err := createArgoCdClients()
 	if err != nil {
-		return fmt.Errorf("error creating ArgoCD clients: %w", err)
+		return argoCdClients{}, fmt.Errorf("error creating ArgoCD clients: %w", err)
 	}
-	return nil
+	return argoClients, nil
 }
 
 type argoCdClients struct {
@@ -556,6 +554,13 @@ func generateDiffOfAComponent(ctx context.Context, commentDiff bool, componentPa
 
 // GenerateDiffOfChangedComponents generates diff of changed components
 func GenerateDiffOfChangedComponents(ctx context.Context, componentsToDiff map[string]bool, prBranch string, repo string, useSHALabelForArgoDicovery bool, createTempAppObjectFromNewApps bool) (hasComponentDiff bool, hasComponentDiffErrors bool, diffResults []DiffResult, err error) {
+
+	// init argoclients
+	argoClients, err := InitArgoClients()
+	if err != nil {
+		log.Fatalf("error initializing argo clients: %v", err)
+	}
+
 	hasComponentDiff = false
 	hasComponentDiffErrors = false
 

--- a/internal/pkg/argocd/argocd_test.go
+++ b/internal/pkg/argocd/argocd_test.go
@@ -11,8 +11,13 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/argoproj/argo-cd/v2/pkg/apiclient/application"
+	"github.com/argoproj/argo-cd/v2/pkg/apiclient/project"
+	"github.com/argoproj/argo-cd/v2/pkg/apiclient/settings"
 	argoappv1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	reposerverApiClient "github.com/argoproj/argo-cd/v2/reposerver/apiclient"
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
 	"github.com/wayfair-incubator/telefonistka/internal/pkg/mocks"
 	"github.com/wayfair-incubator/telefonistka/internal/pkg/testutils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -315,6 +320,7 @@ func TestFindArgocdAppByPathAnnotationNotFound(t *testing.T) {
 }
 
 func TestFetchArgoDiffConcurrently(t *testing.T) {
+	t.Parallel()
 	// MockApplicationServiceClient
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
@@ -326,17 +332,20 @@ func TestFetchArgoDiffConcurrently(t *testing.T) {
 	// mock the argoClients
 	mockAppServiceClient := mocks.NewMockApplicationServiceClient(mockCtrl)
 	mockSettingsServiceClient := mocks.NewMockSettingsServiceClient(mockCtrl)
+	mockProjectServiceClient := mocks.NewMockProjectServiceClient(mockCtrl)
+
 	argoClients = argoCdClients{
 		app:     mockAppServiceClient,
 		setting: mockSettingsServiceClient,
+		project: mockProjectServiceClient,
 	}
 
 	// slowReply simulates a slow reply from the server
 	slowReply := func(ctx context.Context, in any, opts ...any) {
-		time.Sleep(1 * time.Second)
+		time.Sleep(time.Second)
 	}
 
-	// makeComponents
+	// makeComponents for test
 	makeComponents := func(num int) map[string]bool {
 		components := make(map[string]bool, num)
 		for i := 0; i < num; i++ {
@@ -345,26 +354,89 @@ func TestFetchArgoDiffConcurrently(t *testing.T) {
 		return components
 	}
 
-	mockSettingsServiceClient.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, nil)
+	mockSettingsServiceClient.EXPECT().
+		Get(gomock.Any(), gomock.Any()).
+		Return(&settings.Settings{
+			URL: "https://test-argocd.test.test",
+		}, nil)
+	// mock the List method
 	mockAppServiceClient.EXPECT().
 		List(gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(&argoappv1.ApplicationList{}, nil).
+		Return(&argoappv1.ApplicationList{
+			Items: []argoappv1.Application{
+				{
+					TypeMeta:   metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{},
+					Spec:       argoappv1.ApplicationSpec{},
+					Status:     argoappv1.ApplicationStatus{},
+					Operation:  &argoappv1.Operation{},
+				},
+			},
+		}, nil).
 		AnyTimes().
-		Do(slowReply)
-	// type argoCdClients struct {
+		Do(slowReply) // simulate slow reply
+
+	// mock the Get method
+	mockAppServiceClient.EXPECT().
+		Get(gomock.Any(), gomock.Any()).
+		Return(&argoappv1.Application{
+			TypeMeta: metav1.TypeMeta{},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-app",
+			},
+			Spec: argoappv1.ApplicationSpec{
+				Source: &argoappv1.ApplicationSource{
+					TargetRevision: "test-revision",
+				},
+				SyncPolicy: &argoappv1.SyncPolicy{
+					Automated: &argoappv1.SyncPolicyAutomated{},
+				},
+			},
+			Status:    argoappv1.ApplicationStatus{},
+			Operation: &argoappv1.Operation{},
+		}, nil).
+		AnyTimes()
+
+	// mock managedResource
+	mockAppServiceClient.EXPECT().
+		ManagedResources(gomock.Any(), gomock.Any()).
+		Return(&application.ManagedResourcesResponse{}, nil).
+		AnyTimes()
+
+	// mock the GetManifests method
+	mockAppServiceClient.EXPECT().
+		GetManifests(gomock.Any(), gomock.Any()).
+		Return(&reposerverApiClient.ManifestResponse{}, nil).
+		AnyTimes()
+
+	// mock the GetDetailedProject method
+	mockProjectServiceClient.EXPECT().
+		GetDetailedProject(gomock.Any(), gomock.Any()).
+		Return(&project.DetailedProjectsResponse{}, nil).
+		AnyTimes() // type argoCdClients struct {
 	// 	app     application.ApplicationServiceClient
 	// 	project projectpkg.ProjectServiceClient
 	// 	setting settings.SettingsServiceClient
 	// 	appSet  applicationsetpkg.ApplicationSetServiceClient
 	// }
 
-	GenerateDiffOfChangedComponents(
+	const numComponents = 5
+	// start timer
+	start := time.Now()
+
+	// TODO: Test all the return values, for now we will just ignore the linter.
+	_, _, diffResults, _ := GenerateDiffOfChangedComponents( //nolint:dogsled
 		context.TODO(),
-		makeComponents(5),
+		makeComponents(numComponents),
 		"test-pr-branch",
 		"test-repo",
 		true,
 		false,
 	)
 
+	// stop timer
+	elapsed := time.Since(start)
+	assert.Equal(t, numComponents, len(diffResults))
+	// assert that the entire run takes less than numComponents * 1 second
+	assert.Less(t, elapsed, time.Duration(numComponents)*time.Second)
 }

--- a/internal/pkg/argocd/argocd_test.go
+++ b/internal/pkg/argocd/argocd_test.go
@@ -325,25 +325,17 @@ func TestFetchArgoDiffConcurrently(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	argoClients, err := createArgoCdClients()
-	if err != nil {
-		t.Errorf("error creating ArgoCD clients: %v", err)
-	}
-
 	// mock the argoClients
 	mockAppServiceClient := mocks.NewMockApplicationServiceClient(mockCtrl)
 	mockSettingsServiceClient := mocks.NewMockSettingsServiceClient(mockCtrl)
 	mockProjectServiceClient := mocks.NewMockProjectServiceClient(mockCtrl)
 	// fake InitArgoClients
-	InitArgoClients = func() (argoCdClients, error) {
-		argoClients := argoCdClients{
-			app:     mockAppServiceClient,
-			setting: mockSettingsServiceClient,
-			project: mockProjectServiceClient,
-		}
-		return argoClients, nil
-	}
 
+	argoClients := argoCdClients{
+		app:     mockAppServiceClient,
+		setting: mockSettingsServiceClient,
+		project: mockProjectServiceClient,
+	}
 	// slowReply simulates a slow reply from the server
 	slowReply := func(ctx context.Context, in any, opts ...any) {
 		time.Sleep(time.Second)

--- a/internal/pkg/argocd/argocd_test.go
+++ b/internal/pkg/argocd/argocd_test.go
@@ -326,18 +326,21 @@ func TestFetchArgoDiffConcurrently(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	// Save and restore the original argoClients
-	saved := argoClients
-	defer func() { argoClients = saved }()
+	saved := InitArgoClients
+	defer func() { InitArgoClients = saved }()
 
 	// mock the argoClients
 	mockAppServiceClient := mocks.NewMockApplicationServiceClient(mockCtrl)
 	mockSettingsServiceClient := mocks.NewMockSettingsServiceClient(mockCtrl)
 	mockProjectServiceClient := mocks.NewMockProjectServiceClient(mockCtrl)
-
-	argoClients = argoCdClients{
-		app:     mockAppServiceClient,
-		setting: mockSettingsServiceClient,
-		project: mockProjectServiceClient,
+	// fake InitArgoClients
+	InitArgoClients = func() (argoCdClients, error) {
+		argoClients := argoCdClients{
+			app:     mockAppServiceClient,
+			setting: mockSettingsServiceClient,
+			project: mockProjectServiceClient,
+		}
+		return argoClients, nil
 	}
 
 	// slowReply simulates a slow reply from the server

--- a/internal/pkg/argocd/argocd_test.go
+++ b/internal/pkg/argocd/argocd_test.go
@@ -325,9 +325,10 @@ func TestFetchArgoDiffConcurrently(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	// Save and restore the original argoClients
-	saved := InitArgoClients
-	defer func() { InitArgoClients = saved }()
+	argoClients, err := createArgoCdClients()
+	if err != nil {
+		t.Errorf("error creating ArgoCD clients: %v", err)
+	}
 
 	// mock the argoClients
 	mockAppServiceClient := mocks.NewMockApplicationServiceClient(mockCtrl)

--- a/internal/pkg/argocd/argocd_test.go
+++ b/internal/pkg/argocd/argocd_test.go
@@ -413,12 +413,7 @@ func TestFetchArgoDiffConcurrently(t *testing.T) {
 	mockProjectServiceClient.EXPECT().
 		GetDetailedProject(gomock.Any(), gomock.Any()).
 		Return(&project.DetailedProjectsResponse{}, nil).
-		AnyTimes() // type argoCdClients struct {
-	// 	app     application.ApplicationServiceClient
-	// 	project projectpkg.ProjectServiceClient
-	// 	setting settings.SettingsServiceClient
-	// 	appSet  applicationsetpkg.ApplicationSetServiceClient
-	// }
+		AnyTimes()
 
 	const numComponents = 5
 	// start timer

--- a/internal/pkg/argocd/argocd_test.go
+++ b/internal/pkg/argocd/argocd_test.go
@@ -431,6 +431,7 @@ func TestFetchArgoDiffConcurrently(t *testing.T) {
 		"test-repo",
 		true,
 		false,
+		argoClients,
 	)
 
 	// stop timer

--- a/internal/pkg/githubapi/github.go
+++ b/internal/pkg/githubapi/github.go
@@ -224,8 +224,12 @@ func handleChangedPREvent(ctx context.Context, mainGithubClientPair GhClientPair
 				ghPrClientDetails.PrLogger.Debugf("ArgoCD diff disabled for %s\n", componentPath)
 			}
 		}
+		argoClients, err := createArgoCdClients()
+		if err != nil {
+			return fmt.Errorf("error creating ArgoCD clients: %w", err)
+		}
 
-		hasComponentDiff, hasComponentDiffErrors, diffOfChangedComponents, err := argocd.GenerateDiffOfChangedComponents(ctx, componentsToDiff, ghPrClientDetails.Ref, ghPrClientDetails.RepoURL, config.Argocd.UseSHALabelForAppDiscovery, config.Argocd.CreateTempAppObjectFroNewApps)
+		hasComponentDiff, hasComponentDiffErrors, diffOfChangedComponents, err := argocd.GenerateDiffOfChangedComponents(ctx, componentsToDiff, ghPrClientDetails.Ref, ghPrClientDetails.RepoURL, config.Argocd.UseSHALabelForAppDiscovery, config.Argocd.CreateTempAppObjectFroNewApps, argoClients)
 		if err != nil {
 			return fmt.Errorf("getting diff information: %w", err)
 		}

--- a/internal/pkg/githubapi/github.go
+++ b/internal/pkg/githubapi/github.go
@@ -224,6 +224,7 @@ func handleChangedPREvent(ctx context.Context, mainGithubClientPair GhClientPair
 				ghPrClientDetails.PrLogger.Debugf("ArgoCD diff disabled for %s\n", componentPath)
 			}
 		}
+
 		hasComponentDiff, hasComponentDiffErrors, diffOfChangedComponents, err := argocd.GenerateDiffOfChangedComponents(ctx, componentsToDiff, ghPrClientDetails.Ref, ghPrClientDetails.RepoURL, config.Argocd.UseSHALabelForAppDiscovery, config.Argocd.CreateTempAppObjectFroNewApps)
 		if err != nil {
 			return fmt.Errorf("getting diff information: %w", err)

--- a/internal/pkg/githubapi/github.go
+++ b/internal/pkg/githubapi/github.go
@@ -224,7 +224,7 @@ func handleChangedPREvent(ctx context.Context, mainGithubClientPair GhClientPair
 				ghPrClientDetails.PrLogger.Debugf("ArgoCD diff disabled for %s\n", componentPath)
 			}
 		}
-		argoClients, err := createArgoCdClients()
+		argoClients, err := argocd.CreateArgoCdClients()
 		if err != nil {
 			return fmt.Errorf("error creating ArgoCD clients: %w", err)
 		}

--- a/internal/pkg/mocks/mocks.go
+++ b/internal/pkg/mocks/mocks.go
@@ -3,4 +3,7 @@ package mocks
 // This package contains generated mocks
 
 //go:generate go run github.com/golang/mock/mockgen@v1.6.0 -destination=argocd_application.go -package=mocks github.com/argoproj/argo-cd/v2/pkg/apiclient/application ApplicationServiceClient
+
 //go:generate go run github.com/golang/mock/mockgen@v1.6.0 -destination=argocd_settings.go -package=mocks github.com/argoproj/argo-cd/v2/pkg/apiclient/settings SettingsServiceClient
+
+//go:generate go run github.com/golang/mock/mockgen@v1.6.0 -destination=argocd_project.go -package=mocks github.com/argoproj/argo-cd/v2/pkg/apiclient/project ProjectServiceClient

--- a/internal/pkg/mocks/mocks.go
+++ b/internal/pkg/mocks/mocks.go
@@ -3,3 +3,4 @@ package mocks
 // This package contains generated mocks
 
 //go:generate go run github.com/golang/mock/mockgen@v1.6.0 -destination=argocd_application.go -package=mocks github.com/argoproj/argo-cd/v2/pkg/apiclient/application ApplicationServiceClient
+//go:generate go run github.com/golang/mock/mockgen@v1.6.0 -destination=argocd_settings.go -package=mocks github.com/argoproj/argo-cd/v2/pkg/apiclient/settings SettingsServiceClient


### PR DESCRIPTION
## Description

This pull request parallelizes the fetching of argocd diffs in telefonistka.

For testing, I had to make `argoCdClients ` a global inside of the argocd package. This is so that it could be overwritten during testing. As a result, `InitArgoClients()` is called inside the handler to initialize the argocd clients, instead of being called from within the functions needing the client.

## Type of Change

- [ ] Bug Fix
- [X] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](https://github.com/wayfair-incubator/telefonistka/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
