### PR TITLE
Add logging around generating diff comment

### DIFF
--- a/internal/pkg/githubapi/github.go
+++ b/internal/pkg/githubapi/github.go
@@ -261,7 +261,8 @@ func handleChangedPREvent(ctx context.Context, mainGithubClientPair GhClientPair
 			}
 
 			diffCommentData.DisplaySyncBranchCheckBox = shouldSyncBranchCheckBoxBeDisplayed(componentPathList, config.Argocd.AllowSyncfromBranchPathRegex, diffOfChangedComponents)
-
+			componentsToDiffJSON, _ := json.Marshal(componentsToDiff)
+			log.Infof("Generating ArgoCD Diff Comment for components: %+v, length of diff elements: %d", string(componentsToDiffJSON), len(diffCommentData.DiffOfChangedComponents))
 			comments, err := generateArgoCdDiffComments(diffCommentData, githubCommentMaxSize)
 			if err != nil {
 				return fmt.Errorf("generate diff comment: %w", err)


### PR DESCRIPTION
## Description

The change adds a log statement to provide more detailed information about the components being processed for the ArgoCD Diff Comment. This is to help with debugging this issue: [Empty diff instead of No Diff](https://commercetools.atlassian.net/browse/SD-874). My suspicion is that the [diffElements](https://github.com/commercetools/telefonistka/blob/sd-874-add-log-for-empty-diff-instead-of-no-diff/templates/argoCD-diff-pr-comment.gotmpl#L31-L32) is empty, which results in an empty diff comment.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [X] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](https://github.com/wayfair-incubator/telefonistka/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
