### PR TITLE
Support custom generator

### DIFF
--- a/internal/pkg/argocd/argocd.go
+++ b/internal/pkg/argocd/argocd.go
@@ -233,6 +233,27 @@ func findRelevantAppSetByPath(ctx context.Context, componentPath string, repo st
 					}
 				}
 			}
+
+			if generator.Plugin != nil &&
+				generator.Plugin.Input.Parameters != nil {
+				for key, value := range generator.Plugin.Input.Parameters {
+					if key == "path" {
+						var parsedPath string
+
+						if err := json.Unmarshal(value.Raw, &parsedPath); err != nil {
+							return nil, fmt.Errorf("unable to unmarshal plugin generator path: %w", err)
+						}
+
+						match, _ := path.Match(parsedPath, componentPath)
+						if match {
+							log.Debugf("Found ArgoCD ApplicationSet %q for component path %q(repo %s)", appSet.Name, componentPath, repo)
+							return &appSet, nil
+						} else {
+							log.Debugf("No match for %s in %q", componentPath, parsedPath)
+						}
+					}
+				}
+			}
 		}
 	}
 	return nil, fmt.Errorf("No ArgoCD ApplicationSet found for component path %s(repo %s)", componentPath, repo)

--- a/internal/pkg/argocd/argocd_test.go
+++ b/internal/pkg/argocd/argocd_test.go
@@ -57,8 +57,8 @@ func TestFindRelevantAppSetByPathDoesNotExplode(t *testing.T) {
 		componentPath,
 		repo,
 		ac,
-	); err == nil {
-		t.Errorf("got unexpected nil error")
+	); err != nil {
+		t.Errorf("got unexpected error")
 	}
 }
 


### PR DESCRIPTION
If the found ApplicationSet contains no Git configuration Telefonistka crashes.

Guarding against the missing configuration should avoid the crash.

Also adds support for custom generator as long as the generator has an input
parameter named "path".

Note that it would probably be advisable to make it configurable, but
this is left as a future exercise for the reader.
