### PR TITLE
Use empty configuration when not available upstream

### DIFF
--- a/internal/pkg/githubapi/github.go
+++ b/internal/pkg/githubapi/github.go
@@ -1294,7 +1294,7 @@ func GetInRepoConfig(ghPrClientDetails GhPrClientDetails, defaultBranch string) 
 	inRepoConfigFileContentString, _, err := GetFileContent(ghPrClientDetails, defaultBranch, "telefonistka.yaml")
 	if err != nil {
 		ghPrClientDetails.PrLogger.Errorf("Could not get in-repo configuration: err=%s\n", err)
-		return nil, err
+		inRepoConfigFileContentString = ""
 	}
 	c, err := cfg.ParseConfigFromYaml(inRepoConfigFileContentString)
 	if err != nil {


### PR DESCRIPTION
If Telefonistka is connected to a repository that does not have a configuration file it currently fails.

This change will use an empty configuration file for such cases, and only log the error.