### PR TITLE
Run go mod tidy and ensure no diff in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,6 +35,7 @@ jobs:
           go-version: 1.21
       - uses: actions/checkout@v4
       - run: make get-deps
+      - run: go mod tidy -diff
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,9 @@ require (
 	golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67
 	golang.org/x/oauth2 v0.21.0
 	golang.org/x/tools v0.29.0
+	google.golang.org/grpc v1.63.2
 	gopkg.in/yaml.v2 v2.4.0
+	k8s.io/api v0.26.11
 	k8s.io/apimachinery v0.26.11
 )
 
@@ -177,13 +179,11 @@ require (
 	google.golang.org/genproto v0.0.0-20240401170217-c3f982113cda // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240401170217-c3f982113cda // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240401170217-c3f982113cda // indirect
-	google.golang.org/grpc v1.63.2 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/op/go-logging.v1 v1.0.0-20160211212156-b2cb9fa56473 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.26.11 // indirect
 	k8s.io/apiextensions-apiserver v0.26.10 // indirect
 	k8s.io/apiserver v0.26.11 // indirect
 	k8s.io/cli-runtime v0.26.11 // indirect


### PR DESCRIPTION
Not having an up-to-date go.mod file will cause local diffs during development.

This is frustrating and unnecessary.