### PR TITLE
Remove renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "description": "Wayfair OSPO recommended presets (https://github.com/wayfair/ospo-automation/blob/main/default.json)",
-  "extends": [
-    "github>wayfair/ospo-automation"
-  ]
-}


### PR DESCRIPTION
Renovate is not configured for the repository currently in favor of dependabot. This may change, but until it does the renovate configuration file is cleaned up.