### PR TITLE
Avoid app sync/health warnings on app temporarily created by Telefonistka

### DIFF
--- a/templates/argoCD-diff-pr-comment-concise.gotmpl
+++ b/templates/argoCD-diff-pr-comment-concise.gotmpl
@@ -31,7 +31,7 @@ Please be aware:
 {{- end}}
 {{ if  not $appDiffResult.ArgoCdAppAutoSyncEnabled }}
 > [!NOTE]
-> This ArgoCD app is doesn't have `auto-sync` enabled, merging this PR will **not** apply changes to cluster without additional actions.
+> This ArgoCD app doesn't have `auto-sync` enabled, merging this PR will **not** apply changes to cluster without additional actions.
 {{- end}}
 {{- end}}
 {{if $appDiffResult.HasDiff }}

--- a/templates/argoCD-diff-pr-comment-concise.gotmpl
+++ b/templates/argoCD-diff-pr-comment-concise.gotmpl
@@ -14,7 +14,13 @@ Diff of ArgoCD applications(⚠️ concise view, full diff didn't fit GH comment
 
 {{- else }}
 <img src="https://argo-cd.readthedocs.io/en/stable/assets/favicon.png" width="20"/> **[{{ $appDiffResult.ArgoCdAppName }}]({{ $appDiffResult.ArgoCdAppURL }})** @ `{{ $appDiffResult.ComponentPath }}`
-{{if $appDiffResult.HasDiff }}
+
+{{if $appDiffResult.AppWasTemporarilyCreated }}
+> [!NOTE]
+> Telefonistka has temporarily created an ArgoCD app object to render manifest previews.
+Please be aware:
+> * The app will only appear in the ArgoCD UI for a few seconds.
+{{- else }}
 {{ if  ne $appDiffResult.ArgoCdAppHealthStatus "Healthy" }}
 > [!CAUTION]
 > The ArgoCD app health status is currently `{{ $appDiffResult.ArgoCdAppHealthStatus }}`.
@@ -27,6 +33,8 @@ Diff of ArgoCD applications(⚠️ concise view, full diff didn't fit GH comment
 > [!NOTE]
 > This ArgoCD app is doesn't have `auto-sync` enabled, merging this PR will **not** apply changes to cluster without additional actions.
 {{- end}}
+{{- end}}
+{{if $appDiffResult.HasDiff }}
 
 <details><summary>ArgoCD list of changed objects(Click to expand):</summary>
 
@@ -44,12 +52,6 @@ Diff of ArgoCD applications(⚠️ concise view, full diff didn't fit GH comment
 {{- else }}
 
 No diff 🤷
-{{- end}}
-{{if $appDiffResult.AppWasTemporarilyCreated }}
-> [!NOTE]
-> Telefonistka has temporarily created an ArgoCD app object to render manifest previews.
-Please be aware:
-> * The app will only appear in the ArgoCD UI for a few seconds.
 {{- end}}
 
 {{- end }}

--- a/templates/argoCD-diff-pr-comment.gotmpl
+++ b/templates/argoCD-diff-pr-comment.gotmpl
@@ -23,6 +23,13 @@ Please check the App Conditions of <img src="https://argo-cd.readthedocs.io/en/s
 
 {{- else }}
 <img src="https://argo-cd.readthedocs.io/en/stable/assets/favicon.png" width="20"/> **[{{ $appDiffResult.ArgoCdAppName }}]({{ $appDiffResult.ArgoCdAppURL }})** @ `{{ $appDiffResult.ComponentPath }}`
+
+{{if $appDiffResult.AppWasTemporarilyCreated }}
+> [!NOTE]
+> Telefonistka has temporarily created an ArgoCD app object to render manifest previews.
+Please be aware:
+> * The app will only appear in the ArgoCD UI for a few seconds.
+{{- else }}
 {{ if  ne $appDiffResult.ArgoCdAppHealthStatus "Healthy" }}
 > [!CAUTION]
 > The ArgoCD app health status is currently `{{ $appDiffResult.ArgoCdAppHealthStatus }}`.
@@ -34,6 +41,7 @@ Please check the App Conditions of <img src="https://argo-cd.readthedocs.io/en/s
 {{ if  not $appDiffResult.ArgoCdAppAutoSyncEnabled }}
 > [!NOTE]
 > This ArgoCD app is doesn't have `auto-sync` enabled, merging this PR will **not** apply changes to cluster without additional actions.
+{{- end}}
 {{- end}}
 {{if $appDiffResult.HasDiff }}
 
@@ -56,12 +64,6 @@ Please check the App Conditions of <img src="https://argo-cd.readthedocs.io/en/s
 {{- else }}
 
 No diff 🤷
-{{- end}}
-{{if $appDiffResult.AppWasTemporarilyCreated }}
-> [!NOTE]
-> Telefonistka has temporarily created an ArgoCD app object to render manifest previews.
-Please be aware:
-> * The app will only appear in the ArgoCD UI for a few seconds.
 {{- end}}
 
 {{- end }}


### PR DESCRIPTION
## Description
When Telefonsitka create temporary ArgoCD app object to render manifest previews, it will warn the user on app Sync/Health status, that doesn't make sense.

This PR changes the comment template so that it doesn't show the warning when the app was temporarily created by Telefonistka.
Additionally, it change to logic of the concine  PR comment to display the warnings regardless of existence of "diff", this will match the full comment behavior.
Lastly it moves the `Telefonistka has temporarily created an ArgoCD app object to render manifest previews.`  annotation above the Diff content, to make it move visible and match the behavior of the other warnings

 

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](https://github.com/wayfair-incubator/telefonistka/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
