### PR TITLE
Ensure all temp app warning is in the note markdown block

### DIFF
--- a/internal/pkg/githubapi/github.go
+++ b/internal/pkg/githubapi/github.go
@@ -309,7 +309,7 @@ func buildArgoCdDiffComment(diffCommentData DiffCommentData, beConcise bool, par
 
 			// If the app was temporarily created, we should inform the user about it, if not we should inform about "unusual" health and sync status
 			if appDiffResult.AppWasTemporarilyCreated {
-				md.Note("Telefonistka has temporarily created an ArgoCD app object to render manifest previews.  \nPlease be aware:  \n* The app will only appear in the ArgoCD UI for a few seconds.")
+				md.Note("Telefonistka has temporarily created an ArgoCD app object to render manifest previews.  \n> Please be aware:  \n> * The app will only appear in the ArgoCD UI for a few seconds.")
 			} else {
 				if appDiffResult.ArgoCdAppHealthStatus != "Healthy" {
 					md.Cautionf("The ArgoCD app health status is currently %s", appDiffResult.ArgoCdAppHealthStatus)

--- a/internal/pkg/githubapi/testdata/output/TestMarkdownGenerator/Temp_app_should_not_show_sync_or_unhealthy_warnings.md
+++ b/internal/pkg/githubapi/testdata/output/TestMarkdownGenerator/Temp_app_should_not_show_sync_or_unhealthy_warnings.md
@@ -3,8 +3,8 @@ Diff of ArgoCD applications:
 <img src="https://argo-cd.readthedocs.io/en/stable/assets/favicon.png" width="20"/> **[temp-ssllab-test-plg-aws-eu-central1-v1](https://argocd-lab.example.com/applications/temp-ssllab-test-plg-aws-eu-central1-v1)** @ `clusters/playground/aws/eu-central-1/v1/special-delivery/ssllab-test/ssllab-test`
 > [!NOTE]  
 > Telefonistka has temporarily created an ArgoCD app object to render manifest previews.  
-Please be aware:  
-* The app will only appear in the ArgoCD UI for a few seconds.
+> Please be aware:  
+> * The app will only appear in the ArgoCD UI for a few seconds.
 
 <details><summary>ArgoCD Diff(Click to expand):</summary>
 


### PR DESCRIPTION
## Description

Tiny fix for the New App warning formatting, some of the message was outside the markdown Note block, this fixes it

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](https://github.com/wayfair-incubator/telefonistka/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
