### PR TITLE
fix(diff): Add WithStructuredMergeDiff option to argocd NewDiffConfigBuilder

### DIFF
--- a/internal/pkg/argocd/argocd.go
+++ b/internal/pkg/argocd/argocd.go
@@ -107,6 +107,7 @@ func generateArgocdAppDiff(ctx context.Context, keepDiffData bool, app *argoappv
 			WithDiffSettings(app.Spec.IgnoreDifferences, overrides, ignoreAggregatedRoles, ignoreNormalizerOpts).
 			WithTracking(argoSettings.AppLabelKey, argoSettings.TrackingMethod).
 			WithNoCache().
+			WithStructuredMergeDiff(true).
 			Build()
 		if err != nil {
 			return false, nil, fmt.Errorf("Failed to build diff config: %w", err)


### PR DESCRIPTION
See for a detailed explanation of why we need this, and what it does: https://commercetools.atlassian.net/browse/SD-1122?focusedCommentId=912026 

## Description
This ensures that empty maps show up correctly in the diff.
## Before (Telefonistka reports "No Diff"):
![image](https://github.com/user-attachments/assets/a02a27fe-3ed0-4e3a-86d6-8dab33871c62)


## After Fix (Correct Diff):
![image](https://github.com/user-attachments/assets/2b8f724b-2128-492a-bb45-55bd3c376304)

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](https://github.com/wayfair-incubator/telefonistka/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
