### PR TITLE
Inject default values to container image name to avoid CI failure in from-fork PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 <!-- markdownlint-disable MD033 -->
 <p align="center">  <img src="https://user-images.githubusercontent.com/1616153/217223509-9aa60a5c-a263-41a7-814d-a1bf2957acf6.png " width="150"> </p>
 


### PR DESCRIPTION
## Description

Workflows run from forks don't have access to `env.*` variables so they fail the container build stage with:

```
ERROR: invalid tag "/:pr-106": invalid reference format
```

This pr will inject `commercetools/telefonistka` values for those cases **while still supporting forks overriding their image names**.



## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](https://github.com/wayfair-incubator/telefonistka/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
