### PR TITLE
Fix comment event guard

### DIFF
--- a/internal/pkg/githubapi/github.go
+++ b/internal/pkg/githubapi/github.go
@@ -578,10 +578,11 @@ func handleCommentPrEvent(ghPrClientDetails GhPrClientDetails, ce *github.IssueC
 	}
 
 	issue := ce.GetIssue()
+	owner := ghPrClientDetails.Owner
 	repo := ghPrClientDetails.Repo
 
 	// Check if this comment has an attached PR. If it does not we want to skip moving along.
-	pr, err := getPR(ghPrClientDetails.Ctx, ghPrClientDetails.GhClientPair.v3Client.PullRequests, issue.GetUser().GetLogin(), repo, issue.GetNumber())
+	pr, err := getPR(ghPrClientDetails.Ctx, ghPrClientDetails.GhClientPair.v3Client.PullRequests, owner, repo, issue.GetNumber())
 	if pr == nil || err != nil {
 		ghPrClientDetails.PrLogger.Debug("Issue is not a PR")
 		return nil


### PR DESCRIPTION
The commit [1] incorrectly passes issue.user.login as owner when fetching the PR. This causes events to be considered incorrectly.

Revert back to using details.Repo and details.Owner directly and leave further refactoring for later.

[1] 79026b0dd9b0811c20ffbf536693ac33b816996c

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](https://github.com/commercetools/telefonistka/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
