### PR TITLE
Make sure diff does not panic

### DIFF
--- a/internal/pkg/argocd/argocd.go
+++ b/internal/pkg/argocd/argocd.go
@@ -156,6 +156,12 @@ func generateArgocdAppDiff(ctx context.Context, keepDiffData bool, app *argoappv
 // diffLiveVsTargetObject returns the diff of live and target in a format that
 // is compatible with Github markdown diff highlighting.
 func diffLiveVsTargetObject(live, target *unstructured.Unstructured) (string, error) {
+	if live == nil {
+		live = &unstructured.Unstructured{}
+	}
+	if target == nil {
+		target = &unstructured.Unstructured{}
+	}
 	kind := target.GetKind()
 	name := target.GetName()
 	apiVersion := target.GetAPIVersion()

--- a/internal/pkg/argocd/argocd_test.go
+++ b/internal/pkg/argocd/argocd_test.go
@@ -111,6 +111,15 @@ func TestDiffLiveVsTargetObject(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("no panic on nil inputs", func(t *testing.T) {
+		defer func() {
+			if err := recover(); err != nil {
+				t.Errorf("got panic: %v", err)
+			}
+		}()
+		diffLiveVsTargetObject(nil, nil) //nolint:errcheck // only interested in panic
+	})
 }
 
 func TestRenderDiff(t *testing.T) {


### PR DESCRIPTION
## Description

Protects against cases where `live` and `target` are nil by initializing them to empty `unstructured.Unstructured` objects.

Probably not the ideal solution, but for now just trying to squash the panic and making sure integration testing works out of the box without failures.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](https://github.com/commercetools/telefonistka/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
