### PR TITLE
Remove renovate config

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,14 +18,6 @@ jobs:
         with:
           config: '.markdownlint.json'
           args: '*.md docs/*.md .github/**/*.md'
-  renovate:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: 🧼 lint renovate config # Validates changes to renovate.json config file
-        uses: suzuki-shunsuke/github-action-renovate-config-validator@v1.1.1
-        with:
-          config_file_path: 'renovate.json'
   golangci:
     name: golangci-lint
     runs-on: ubuntu-latest

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "description": "Wayfair OSPO recommended presets (https://github.com/wayfair/ospo-automation/blob/main/default.json)",
-  "extends": [
-    "github>wayfair/ospo-automation"
-  ]
-}


### PR DESCRIPTION
Renovate is not configured for the repository currently in favour of Dependabot. This may change, but until it does the renovate configuration file is cleaned up.