### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,8 @@
 name: lint
 
+permissions:
+  contents: read
+
 on: # Rebuild any PRs and main branch changes
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/commercetools/telefonistka/security/code-scanning/4](https://github.com/commercetools/telefonistka/security/code-scanning/4)

To fix the issue, we will add a `permissions` block to the root of the workflow file. This block will define the minimal permissions required for the workflow to function. Since the workflow primarily performs linting tasks, it likely only needs `contents: read` permissions. This will ensure that the `GITHUB_TOKEN` has the least privilege necessary to execute the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
