### PR TITLE
Change Dependabot cadence to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,4 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"


### PR DESCRIPTION
The number of weekly pull requests raised puts too much strain on the maintaining team and it was decided that the cadence would change to monthly to create a montly focal point where they can be addressed and merged as part of the regular team work instead of as part of ad-hoc requests.