### PR TITLE
Promotion pr labels

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -127,6 +127,7 @@ Configuration keys:
 |`promotionPaths[0].promotionPrs`|  Array of structures, each element represent a PR that will be opened when files are changed under `sourcePath`. Multiple elements means multiple PR will be opened|
 |`promotionPaths[0].promotionPrs[0].targetPaths`| Array of strings, each element represent a directory to by synced from the changed component under  `sourcePath`. Multiple elements means multiple directories will be synced in a PR|
 |`promotionPaths[0].promotionPrs[0].targetDescription`| An optional string that describes the target paths, will be used in the promotion PR titles, for example "All Staging Clusters" or "Production Tier 2 Clusters". If this value is not provided Telefonistka will concatenate all `targetPaths` in the PR title which can make it very long and unreadable. Regardless of this configuration key, the PR titles will always start with the component name, e.g. `🚀 Promotion: nginx ➡️ Production Tier 2 Clusters` |
+|`promotionPaths[0].promotionPrs[0].labels`| An optional array of labels to apply to this specific promotion PR. These labels will be merged with the top-level `promotionPrLabels`. Use this to apply different labels to different promotion flows (e.g., `staging` label for staging promotions, `prod-us` for US production). Duplicate labels across top-level and PR-specific configurations are automatically deduplicated. |
 |`dryRunMode`| if true, the bot will just comment the planned promotion on the merged PR|
 |`autoApprovePromotionPrs`| if true the bot will auto-approve all promotion PRs, with the assumption the original PR was peer reviewed and is promoted verbatim. Required additional GH token via APPROVER_GITHUB_OAUTH_TOKEN env variable|
 |`toggleCommitStatus`| Map of strings, allow (non-repo-admin) users to change the [Github commit status](https://docs.github.com/en/rest/commits/statuses) state(from failure to success and back). This can be used to continue promotion of a change that doesn't pass repo checks. the keys are strings commented in the PRs, values are [Github commit status context](https://docs.github.com/en/rest/commits/statuses?apiVersion=2022-11-28#create-a-commit-status) to be overridden|
@@ -147,6 +148,8 @@ promotionPaths:
       autoMerge: true
     promotionPrs:
       - targetDescription: "All non-production clusters"
+        labels:
+          - "staging"
         targetPaths:
         - "clusters/dev/us-east4/c2"
         - "clusters/lab/europe-west4/c1"
@@ -159,9 +162,13 @@ promotionPaths:
         - "quick_promotion" # This flow will run only if PR has "quick_promotion" label, see targetPaths below
     promotionPrs:
       - targetDescription: "Production clusters tier 1"
+        labels:
+          - "prod-us"
         targetPaths:
         - "clusters/prod/us-west1/c2" # First PR for only a single cluster
       - targetDescription: "Production clusters tier 2"
+        labels:
+          - "prod-multi-region"
         targetPaths:
         - "clusters/prod/europe-west3/c2" # 2nd PR will sync all 4 remaining clusters
         - "clusters/prod/europe-west4/c2"
@@ -181,6 +188,8 @@ promotionPaths:
         - "clusters/prod/us-east4/c2"
 dryRunMode: true
 autoApprovePromotionPrs: true
+promotionPrLabels:
+  - "promotion"
 argocd:
   commentDiffonPR: true
   autoMergeNoDiffPRs: true

--- a/internal/pkg/configuration/config.go
+++ b/internal/pkg/configuration/config.go
@@ -23,6 +23,7 @@ type Condition struct {
 type PromotionPr struct {
 	TargetDescription string   `yaml:"targetDescription"`
 	TargetPaths       []string `yaml:"targetPaths"`
+	Labels            []string `yaml:"labels"`
 }
 
 type PromotionPath struct {

--- a/internal/pkg/configuration/config.go
+++ b/internal/pkg/configuration/config.go
@@ -37,7 +37,7 @@ type Config struct {
 	PromotionPaths []PromotionPath `yaml:"promotionPaths"`
 
 	// Generic configuration
-	PromtionPrLables             []string               `yaml:"promtionPRlables"`
+	PromotionPrLabels            []string               `yaml:"promotionPrLabels"`
 	DryRunMode                   bool                   `yaml:"dryRunMode"`
 	AutoApprovePromotionPrs      bool                   `yaml:"autoApprovePromotionPrs"`
 	ToggleCommitStatus           map[string]string      `yaml:"toggleCommitStatus"`

--- a/internal/pkg/configuration/config_test.go
+++ b/internal/pkg/configuration/config_test.go
@@ -36,6 +36,9 @@ func TestConfigurationParse(t *testing.T) {
 						TargetPaths: []string{
 							"env/staging/us-east4/c1/",
 						},
+						Labels: []string{
+							"staging",
+						},
 					},
 					{
 						TargetPaths: []string{
@@ -53,6 +56,9 @@ func TestConfigurationParse(t *testing.T) {
 					{
 						TargetPaths: []string{
 							"env/prod/us-central1/c2/",
+						},
+						Labels: []string{
+							"prod-us",
 						},
 					},
 				},
@@ -73,6 +79,8 @@ func TestConfigurationParse(t *testing.T) {
 			},
 		},
 	}
+
+	expectedConfig.PromotionPrLabels = []string{"promotion"}
 
 	if diff := deep.Equal(expectedConfig, config); diff != nil {
 		t.Error(diff)

--- a/internal/pkg/configuration/tests/testConfigurationParsing.yaml
+++ b/internal/pkg/configuration/tests/testConfigurationParsing.yaml
@@ -7,6 +7,8 @@ promotionPaths:
     promotionPrs:
       - targetPaths:
         - "env/staging/us-east4/c1/"
+        labels:
+        - "staging"
       - targetPaths:
         - "env/staging/europe-west4/c1/"
   - sourcePath: "env/staging/us-east4/c1/"
@@ -15,6 +17,8 @@ promotionPaths:
     promotionPrs:
       - targetPaths:
         - "env/prod/us-central1/c2/"
+        labels:
+        - "prod-us"
   - sourcePath: "env/prod/us-central1/c2/"
     conditions:
     promotionPrs:

--- a/internal/pkg/configuration/tests/testConfigurationParsing.yaml
+++ b/internal/pkg/configuration/tests/testConfigurationParsing.yaml
@@ -22,7 +22,7 @@ promotionPaths:
         - "env/prod/us-west1/c2/"
         - "env/prod/us-central1/c3/"
 
-promtionPrLables:
+promotionPrLabels:
   - "promotion"
 promotionBranchNameTemplte: "promotions/{{.safeBranchName}}"
 promtionPrBodyTemplate: |

--- a/internal/pkg/githubapi/promotion.go
+++ b/internal/pkg/githubapi/promotion.go
@@ -25,6 +25,7 @@ type PromotionInstanceMetaData struct {
 	PerComponentSkippedTargetPaths map[string][]string // ComponentName is the key,
 	ComponentNames                 []string
 	AutoMerge                      bool
+	Labels                         []string
 }
 
 func containMatchingRegex(patterns []string, str string) bool {
@@ -231,6 +232,7 @@ func generatePlanBasedOnChangeddComponent(ghPrClientDetails GhPrClientDetails, c
 								ComponentNames:                 []string{componentToPromote.ComponentName},
 								PerComponentSkippedTargetPaths: map[string][]string{},
 								AutoMerge:                      componentToPromote.AutoMerge,
+								Labels:                         ppr.Labels,
 							},
 							ComputedSyncPaths: map[string]string{},
 						}

--- a/schema/telefonistka.json
+++ b/schema/telefonistka.json
@@ -86,7 +86,7 @@
         "$ref": "#/definitions/path"
       }
     },
-    "promtionPRlables": {
+    "promotionPrLabels": {
       "type": "array",
       "description": "List of labels to apply on PR",
       "items": {

--- a/schema/telefonistka.json
+++ b/schema/telefonistka.json
@@ -57,6 +57,13 @@
         "targetDescription": {
           "type": "string",
           "description": "An optional string that describes the target paths, will be used in the promotion PR titles"
+        },
+        "labels": {
+          "type": "array",
+          "description": "An optional list of labels to apply to this promotion PR. These labels will be merged with the top-level promotionPrLabels.",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },


### PR DESCRIPTION
## Description

This pull request introduces support for specifying custom labels for individual promotion PRs in the configuration, and ensures these labels are merged with top-level promotion PR labels without duplicates. The changes update the configuration schema, documentation, and implementation, and add comprehensive tests for the label merging logic.

### Configuration and Documentation Updates

* Added a new `labels` field to the `promotionPrs` configuration, allowing users to specify custom labels for each promotion PR. The documentation (`docs/installation.md`) and schema (`schema/telefonistka.json`) were updated to reflect this change. [[1]](diffhunk://#diff-8b042e3f94ca5c59a7cd990b950aec0073ea84fe811e7b22be51158d7b180d56R130) [[2]](diffhunk://#diff-e9c533475741aa4f4e2d1585ed7ebeea89d6b9484394fb4de043de9161764704R60-R66)
* Renamed the top-level configuration key from `promtionPRlables` to `promotionPrLabels` for clarity and consistency in docs, schema, and code. [[1]](diffhunk://#diff-8b042e3f94ca5c59a7cd990b950aec0073ea84fe811e7b22be51158d7b180d56R191-R192) [[2]](diffhunk://#diff-e9c533475741aa4f4e2d1585ed7ebeea89d6b9484394fb4de043de9161764704L89-R96) [[3]](diffhunk://#diff-feb81af7e47b8d0f0591ac857df4896bb89f167b694ce416cf6d5756640f7a11L40-R41)

### Implementation Changes

* Updated the `PromotionPr` struct to include the new `Labels` field, and ensured it is passed through the promotion planning logic. [[1]](diffhunk://#diff-feb81af7e47b8d0f0591ac857df4896bb89f167b694ce416cf6d5756640f7a11R26) [[2]](diffhunk://#diff-0a41799043384229949354e45f76bc9782955e2ce79964db03da188fcf5354b2R28) [[3]](diffhunk://#diff-0a41799043384229949354e45f76bc9782955e2ce79964db03da188fcf5354b2R235)
* Added a `mergeLabels` function to deduplicate and merge top-level and PR-specific labels, and integrated it into the PR creation flow. The `createPrObject` function now accepts a labels parameter and applies merged labels to PRs. [[1]](diffhunk://#diff-7026d4022cf2566206acc90b901d7e6b0dd6969e5ef2f862c963f6552b7becfeR673-R697) [[2]](diffhunk://#diff-7026d4022cf2566206acc90b901d7e6b0dd6969e5ef2f862c963f6552b7becfeL781-R809) [[3]](diffhunk://#diff-7026d4022cf2566206acc90b901d7e6b0dd6969e5ef2f862c963f6552b7becfeL1318-R1346) [[4]](diffhunk://#diff-7026d4022cf2566206acc90b901d7e6b0dd6969e5ef2f862c963f6552b7becfeL1336-R1374)

### Testing

* Added and updated unit tests to verify correct parsing of the new configuration options and the label merging logic, including edge cases for duplicate and overlapping labels. [[1]](diffhunk://#diff-4e880a8ba8689306a9c45b90230359714136473c7f98509b6d918a66b5e06913R39-R41) [[2]](diffhunk://#diff-4e880a8ba8689306a9c45b90230359714136473c7f98509b6d918a66b5e06913R60-R62) [[3]](diffhunk://#diff-4e880a8ba8689306a9c45b90230359714136473c7f98509b6d918a66b5e06913R83-R84) [[4]](diffhunk://#diff-d34eabe7c2435238517adacd977c66ec56021487bfd1f07e8a99c9e5c6313f99R10-R11) [[5]](diffhunk://#diff-d34eabe7c2435238517adacd977c66ec56021487bfd1f07e8a99c9e5c6313f99R20-R29) [[6]](diffhunk://#diff-efa540b5fb84825609760caa99afa47cef9362bae91d5522fb699c91c83c5cabR631-R699)

These changes make promotion PR labeling more flexible and robust, improving both configuration clarity and downstream automation.

## Type of Change

- [x] Bug Fix
- [x] New Feature
- [x] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](https://github.com/commercetools/telefonistka/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
